### PR TITLE
fix step-response high-low

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -11,39 +11,76 @@ pub const PLOT_HEIGHT: u32 = 1080;
 // Step response plot duration in seconds.
 pub const STEP_RESPONSE_PLOT_DURATION_S: f64 = 0.5;
 
-// Constants for the new step response calculation method (inspired by Python)
-pub const FRAME_LENGTH_S: f64 = 1.0; // Length of each window in seconds
-pub const RESPONSE_LENGTH_S: f64 = 0.5; // Length of the step response to keep from each window
-pub const SUPERPOSITION_FACTOR: usize = 16; // Number of overlapping windows within a frame length
-pub const TUKEY_ALPHA: f64 = 1.0; // Alpha for Tukey window (1.0 is Hanning window)
+// Constants for the step response calculation method (mimicking PTstepcalc.m)
+pub const FRAME_LENGTH_S: f64 = 2.0; // Length of each window in seconds (Matlab uses 2s)
+pub const RESPONSE_LENGTH_S: f64 = 0.5; // Length of the step response to keep (500ms, matches PTstepcalc's wnd/StepRespDuration_ms)
+pub const SUPERPOSITION_FACTOR: usize = 16; // Number of overlapping windows within a frame length (can be tuned)
+pub const TUKEY_ALPHA: f64 = 1.0; // Alpha for Tukey window (1.0 is Hanning window, matches PTstepcalc)
 
-// Default setpoint threshold, can be overridden at runtime
+// Initial Gyro Smoothing (applied before deconvolution)
+// 0 for no smoothing. Otherwise, window size for moving average.
+// PTstepcalc uses LOESS with variable window (e.g., 20, 40, 60 samples based on smoothFactor).
+// A simple moving average is implemented here; 10-20 might be a starting point if > 0.
+// For PTB similarity, some level of pre-smoothing is often beneficial.
+pub const INITIAL_GYRO_SMOOTHING_WINDOW: usize = 15; // Example: Set to 10 or 20 to enable, or 0 to disable
+
+// Individual Response "Y-Correction" (Normalization before averaging, mimics PTB)
+pub const APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION: bool = true;
+// If Y-correction is applied, this is the minimum absolute mean of the unnormalized steady-state
+// required to attempt the correction. Prevents extreme scaling/division by near-zero.
+pub const Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS: f32 = 0.1; // Tune this threshold if needed
+
+// Quality Control for *individually Y-corrected* (or uncorrected if Y_CORRECTION flag is false) responses
+// These values mimic PTstepcalc.m's QC: min > 0.5 && max < 3 on the (potentially) Y-corrected steady-state.
+pub const NORMALIZED_STEADY_STATE_MIN_VAL: f32 = 0.5;
+pub const NORMALIZED_STEADY_STATE_MAX_VAL: f32 = 3.0;
+
+// Optional: Additional check on the mean of the Y-corrected steady-state.
+// If enabled, the mean of the Y-corrected steady state should be within these bounds.
+pub const ENABLE_NORMALIZED_STEADY_STATE_MEAN_CHECK: bool = true;
+pub const NORMALIZED_STEADY_STATE_MEAN_MIN: f32 = 0.75; // e.g., mean should be > 0.75 after Y-correction
+pub const NORMALIZED_STEADY_STATE_MEAN_MAX: f32 = 1.25; // e.g., mean should be < 1.25 after Y-correction
+
+// Steady-state definition for Y-correction and QC (matches PTstepcalc.m: 200ms to 500ms of the 500ms response)
+pub const STEADY_STATE_START_S: f64 = 0.2; // Start time for steady-state check (200ms into the 500ms response)
+pub const STEADY_STATE_END_S: f64 = 0.5;   // End time for steady-state check (effectively to the end of RESPONSE_LENGTH_S)
+
+// Constant for post-averaging smoothing of the final step response curves.
+// This is applied in the plotting stage, after responses are averaged.
+pub const POST_AVERAGING_SMOOTHING_WINDOW: usize = 15; // Moving average window size (in samples), you set this to 15
+
+/*
+// Constants for previous unnormalized step-response Quality-Control (Now superseded by Y-correction approach)
+pub const UNNORMALIZED_MEAN_THRESHOLD_FOR_RELATIVE_STD_CHECK: f32 = 1.0;
+pub const UNNORMALIZED_RELATIVE_STD_DEV_MAX: f32 = 0.35;
+pub const UNNORMALIZED_ABSOLUTE_STD_DEV_MAX_FOR_SMALL_MEAN: f32 = 0.55;
+*/
+
+// Default setpoint threshold, can be overridden at runtime for categorizing responses
 pub const DEFAULT_SETPOINT_THRESHOLD: f64 = 500.0;
 
 // Constants for filtering data based on movement and flight phase.
-pub const MOVEMENT_THRESHOLD_DEG_S: f64 = 20.0; // Minimum setpoint/gyro magnitude for a window to be considered for analysis (from both PlasmaTree and PIDtoolbox)
+pub const MOVEMENT_THRESHOLD_DEG_S: f64 = 20.0; // Minimum setpoint/gyro magnitude for a window to be considered (from PTB/PlasmaTree)
 pub const EXCLUDE_START_S: f64 = 3.0; // Exclude this many seconds from the start of the log
 pub const EXCLUDE_END_S: f64 = 3.0; // Exclude this many seconds from the end of the log
 
-// Constant for post-averaging smoothing of the step response curves.
-pub const POST_AVERAGING_SMOOTHING_WINDOW: usize = 5; // Moving average window size (in samples)
 
 // Constants for the spectrum plot (linear amplitude)
 pub const SPECTRUM_Y_AXIS_FLOOR: f64 = 20000.0; // Maximum amplitude for spectrum plots.
-pub const SPECTRUM_NOISE_FLOOR_HZ: f64 = 70.0; // Frequency threshold below which to ignore for dynamic Y-axis scaling (e.g., motor idle noise).
-pub const SPECTRUM_Y_AXIS_HEADROOM_FACTOR: f64 = 1.2; // Factor to extend Y-axis above the highest peak (after noise floor) for better visibility.
+pub const SPECTRUM_NOISE_FLOOR_HZ: f64 = 70.0; // Frequency threshold below which to ignore for dynamic Y-axis scaling
+pub const SPECTRUM_Y_AXIS_HEADROOM_FACTOR: f64 = 1.2; // Factor to extend Y-axis above the highest peak
 pub const PEAK_LABEL_MIN_AMPLITUDE: f64 = 1000.0;
 
 // Constants for PSD plots (dB scale)
 pub const PSD_Y_AXIS_FLOOR_DB: f64 = -80.0; // A reasonable floor for PSD values in dB
-pub const PSD_Y_AXIS_HEADROOM_FACTOR_DB: f64 = 10.0; // Factor to extend Y-axis above the highest peak (in dB, e.g., 10 dB headroom)
-pub const PSD_PEAK_LABEL_MIN_VALUE_DB: f64 = -60.0; // Minimum PSD value in dB for a peak to be labeled. (Adjust as needed)
+pub const PSD_Y_AXIS_HEADROOM_FACTOR_DB: f64 = 10.0; // Factor to extend Y-axis above the highest peak (in dB)
+pub const PSD_PEAK_LABEL_MIN_VALUE_DB: f64 = -60.0; // Minimum PSD value in dB for a peak to be labeled.
 
 // Constants for Spectrogram/Heatmap plots (re-introduced)
 pub const STFT_WINDOW_DURATION_S: f64 = 0.1; // Duration of each STFT window in seconds
 pub const STFT_OVERLAP_FACTOR: f64 = 0.75; // Overlap between windows (e.g., 0.75 for 75% overlap)
 pub const HEATMAP_MIN_PSD_DB: f64 = -80.0; // Minimum PSD value in dB for heatmap color scaling
-pub const HEATMAP_MAX_PSD_DB: f64 = -10.0; // Maximum PSD value in dB for heatmap color scaling (adjust based on typical values)
+pub const HEATMAP_MAX_PSD_DB: f64 = -10.0; // Maximum PSD value in dB for heatmap color scaling
 
 // Constants for Throttle-Frequency Heatmap
 pub const THROTTLE_Y_BINS_COUNT: usize = 50; // Number of bins for the throttle (Y) axis
@@ -56,14 +93,8 @@ pub const MIN_SECONDARY_PEAK_RATIO: f64 = 0.05; // Secondary peak must be ≥ th
 pub const MIN_PEAK_SEPARATION_HZ: f64 = 70.0; // Minimum frequency separation between reported peaks on spectrum plots
 // Constants for advanced peak detection
 pub const ENABLE_WINDOW_PEAK_DETECTION: bool = true; // Set to true to use window-based peak detection
-                                                     // Set to false to use the previous 3-point (amp > prev && amp >= next) logic.
 pub const PEAK_DETECTION_WINDOW_RADIUS: usize = 3;   // Radius W for peak detection window (total 2*W+1 points).
 
-// Constants for individual window step response quality control (from PTstepcalc.m)
-pub const STEADY_STATE_START_S: f64 = 0.2; // Start time for steady-state check within the response window (relative to response start)
-pub const STEADY_STATE_END_S: f64 = 0.5; // End time for steady-state check within the response window (relative to response start)
-pub const STEADY_STATE_MIN_VAL: f64 = 0.5; // Minimum allowed value in steady-state for quality control (applied to UN-NORMALIZED response mean)
-pub const STEADY_STATE_MAX_VAL: f64 = 3.0; // Maximum allowed value in steady-state for quality control (applied to UN-NORMALIZED response)
 
 // --- Plot Color Assignments (Based on Screenshots) ---
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -11,17 +11,16 @@ pub const PLOT_HEIGHT: u32 = 1080;
 // Step response plot duration in seconds.
 pub const STEP_RESPONSE_PLOT_DURATION_S: f64 = 0.5;
 
-// Constants for the step response calculation method (mimicking PTstepcalc.m)
-pub const FRAME_LENGTH_S: f64 = 2.0; // Length of each window in seconds (Matlab uses 2s)
+// Constants for the step response calculation method (mimicking PlasmaTree and PTB PTstepcalc.m)
+pub const FRAME_LENGTH_S: f64 = 2.0; // Length of each window in seconds (PTB uses 2s)
 pub const RESPONSE_LENGTH_S: f64 = 0.5; // Length of the step response to keep (500ms)
 pub const SUPERPOSITION_FACTOR: usize = 16; // Number of overlapping windows (can be tuned)
 pub const TUKEY_ALPHA: f64 = 1.0; // Alpha for Tukey window (1.0 is Hanning window)
 
-// Initial Gyro Smoothing (applied before deconvolution)
-pub const INITIAL_GYRO_SMOOTHING_WINDOW: usize = 15; // Set to 15 based on user's last test
+pub const INITIAL_GYRO_SMOOTHING_WINDOW: usize = 15; // // Initial Gyro Smoothing (applied before deconvolution)
+pub const POST_AVERAGING_SMOOTHING_WINDOW: usize = 15; // Constant for post-averaging smoothing of the final step response curves.
 
-// Individual Response "Y-Correction" (Normalization before averaging)
-pub const APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION: bool = true;
+pub const APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION: bool = true; // Individual Response "Y-Correction" (Normalization before averaging)
 // If Y-correction is applied, this is the minimum absolute mean of the unnormalized steady-state
 // required to attempt the correction. Prevents extreme scaling/division by near-zero.
 pub const Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS: f32 = 0.1; // Tune this threshold if needed (0.1 is a common starting point)
@@ -36,18 +35,12 @@ pub const ENABLE_NORMALIZED_STEADY_STATE_MEAN_CHECK: bool = true;
 pub const NORMALIZED_STEADY_STATE_MEAN_MIN: f32 = 0.75; // e.g., mean should be > 0.75 after Y-correction
 pub const NORMALIZED_STEADY_STATE_MEAN_MAX: f32 = 1.25; // e.g., mean should be < 1.25 after Y-correction
 
-// Steady-state definition for Y-correction and QC (matches PTstepcalc.m: 200ms to 500ms of the 500ms response)
+// Steady-state definition for Y-correction and QC (matches PTB PTstepcalc.m: 200ms to 500ms of the 500ms response)
 pub const STEADY_STATE_START_S: f64 = 0.2; // Start time for steady-state check (200ms into the 500ms response)
 pub const STEADY_STATE_END_S: f64 = 0.5;   // End time for steady-state check (effectively to the end of RESPONSE_LENGTH_S)
 
-// Constant for post-averaging smoothing of the final step response curves.
-pub const POST_AVERAGING_SMOOTHING_WINDOW: usize = 15; // Kept at 15 as per user's last setting
-
-// Final tolerance for normalized steady-state mean in step response plot
-pub const FINAL_NORMALIZED_STEADY_STATE_TOLERANCE: f64 = 0.15;
-
-// Default setpoint threshold, can be overridden at runtime for categorizing responses
-pub const DEFAULT_SETPOINT_THRESHOLD: f64 = 500.0;
+pub const FINAL_NORMALIZED_STEADY_STATE_TOLERANCE: f64 = 0.15; // Final tolerance for normalized steady-state mean in step response plot
+pub const DEFAULT_SETPOINT_THRESHOLD: f64 = 500.0; // Default setpoint threshold, can be overridden at runtime for categorizing responses
 
 // Constants for filtering data based on movement and flight phase.
 pub const MOVEMENT_THRESHOLD_DEG_S: f64 = 20.0; // Minimum setpoint/gyro magnitude (from PTB/PlasmaTree)
@@ -55,48 +48,57 @@ pub const EXCLUDE_START_S: f64 = 3.0; // Exclude seconds from the start of the l
 pub const EXCLUDE_END_S: f64 = 3.0; // Exclude seconds from the end of the log
 
 // Constants for the spectrum plot (linear amplitude)
-pub const SPECTRUM_Y_AXIS_FLOOR: f64 = 20000.0;
-pub const SPECTRUM_NOISE_FLOOR_HZ: f64 = 70.0;
-pub const SPECTRUM_Y_AXIS_HEADROOM_FACTOR: f64 = 1.2;
-pub const PEAK_LABEL_MIN_AMPLITUDE: f64 = 1000.0;
+pub const SPECTRUM_Y_AXIS_FLOOR: f64 = 20000.0; // Maximum amplitude for spectrum plots.
+pub const SPECTRUM_NOISE_FLOOR_HZ: f64 = 70.0; // Frequency threshold below which to ignore for dynamic Y-axis scaling (e.g., motor idle noise).
+pub const SPECTRUM_Y_AXIS_HEADROOM_FACTOR: f64 = 1.2; // Factor to extend Y-axis above the highest peak (after noise floor) for better visibility.
+pub const PEAK_LABEL_MIN_AMPLITUDE: f64 = 1000.0; // Ignore peaks under this; Tunable
 
 // Constants for PSD plots (dB scale)
-pub const PSD_Y_AXIS_FLOOR_DB: f64 = -80.0;
-pub const PSD_Y_AXIS_HEADROOM_FACTOR_DB: f64 = 10.0;
-pub const PSD_PEAK_LABEL_MIN_VALUE_DB: f64 = -60.0;
+pub const PSD_Y_AXIS_FLOOR_DB: f64 = -80.0; // A reasonable floor for PSD values in dB
+pub const PSD_Y_AXIS_HEADROOM_FACTOR_DB: f64 = 10.0; // Factor to extend Y-axis above the highest peak (in dB, e.g., 10 dB headroom)
+pub const PSD_PEAK_LABEL_MIN_VALUE_DB: f64 = -60.0; // Minimum PSD value in dB for a peak to be labeled. (Tune as needed)
 
 // Constants for Spectrogram/Heatmap plots
-pub const STFT_WINDOW_DURATION_S: f64 = 0.1;
-pub const STFT_OVERLAP_FACTOR: f64 = 0.75;
-pub const HEATMAP_MIN_PSD_DB: f64 = -80.0;
-pub const HEATMAP_MAX_PSD_DB: f64 = -10.0;
+pub const STFT_WINDOW_DURATION_S: f64 = 0.1; // Duration of each STFT window in seconds
+pub const STFT_OVERLAP_FACTOR: f64 = 0.75; // Overlap between windows (e.g., 0.75 for 75% overlap)
+pub const HEATMAP_MIN_PSD_DB: f64 = -80.0; // Minimum PSD value in dB for heatmap color scaling
+pub const HEATMAP_MAX_PSD_DB: f64 = -10.0; // Maximum PSD value in dB for heatmap color scaling (adjust based on typical values)
 
 // Constants for Throttle-Frequency Heatmap
-pub const THROTTLE_Y_BINS_COUNT: usize = 50;
-pub const THROTTLE_Y_MIN_VALUE: f64 = 0.0;
-pub const THROTTLE_Y_MAX_VALUE: f64 = 1000.0;
+pub const THROTTLE_Y_BINS_COUNT: usize = 50; // Number of bins for the throttle (Y) axis
+pub const THROTTLE_Y_MIN_VALUE: f64 = 0.0; // Minimum throttle value for plotting range
+pub const THROTTLE_Y_MAX_VALUE: f64 = 1000.0; // Maximum throttle value for plotting range
 
 // Constants for spectrum peak labeling
-pub const MAX_PEAKS_TO_LABEL: usize = 3;
-pub const MIN_SECONDARY_PEAK_RATIO: f64 = 0.05;
-pub const MIN_PEAK_SEPARATION_HZ: f64 = 70.0;
-pub const ENABLE_WINDOW_PEAK_DETECTION: bool = true;
-pub const PEAK_DETECTION_WINDOW_RADIUS: usize = 3;
+pub const MAX_PEAKS_TO_LABEL: usize = 3; // Max number of peaks (including primary) to label on spectrum plots
+pub const MIN_SECONDARY_PEAK_RATIO: f64 = 0.05; // Secondary peak must be ≥ this linear ratio of the primary peak’s amplitude
+pub const MIN_PEAK_SEPARATION_HZ: f64 = 70.0; // Minimum frequency separation between reported peaks on spectrum plots
 
-// --- Plot Color Assignments ---
+// Constants for advanced peak detection
+pub const ENABLE_WINDOW_PEAK_DETECTION: bool = true; // Set to true to use window-based peak detection
+                                                     // Set to false to use the previous 3-point (amp > prev && amp >= next) logic.
+pub const PEAK_DETECTION_WINDOW_RADIUS: usize = 3;   // Radius W for peak detection window (total 2*W+1 points).
+
+// PIDsum vs PID Error vs Setpoint Plot
 pub const COLOR_PIDSUM_MAIN: &RGBColor = &GREEN;
 pub const COLOR_PIDERROR_MAIN: &RGBColor = &PURPLE;
 pub const COLOR_SETPOINT_MAIN: &RGBColor = &ORANGE;
+
+// Setpoint vs Gyro Plot
 pub const COLOR_SETPOINT_VS_GYRO_SP: &RGBColor = &ORANGE;
 pub const COLOR_SETPOINT_VS_GYRO_GYRO: &RGBColor = &LIGHTBLUE;
+
+// Gyro vs Unfilt Gyro Plot
 pub const COLOR_GYRO_VS_UNFILT_FILT: &RGBColor = &LIGHTBLUE;
 pub const COLOR_GYRO_VS_UNFILT_UNFILT: &RGBColor = &AMBER;
+
+// Step Response Plot
 pub const COLOR_STEP_RESPONSE_LOW_SP: &RGBColor = &LIGHTBLUE;
 pub const COLOR_STEP_RESPONSE_HIGH_SP: &RGBColor = &ORANGE;
 pub const COLOR_STEP_RESPONSE_COMBINED: &RGBColor = &RED;
 
 // Stroke widths for lines
-pub const LINE_WIDTH_PLOT: u32 = 1;
-pub const LINE_WIDTH_LEGEND: u32 = 2;
+pub const LINE_WIDTH_PLOT: u32 = 1; // Width for plot lines
+pub const LINE_WIDTH_LEGEND: u32 = 2; // Width for legend lines
 
 // src/constants.rs

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -43,12 +43,8 @@ pub const STEADY_STATE_END_S: f64 = 0.5;   // End time for steady-state check (e
 // Constant for post-averaging smoothing of the final step response curves.
 pub const POST_AVERAGING_SMOOTHING_WINDOW: usize = 15; // Kept at 15 as per user's last setting
 
-/*
-// Constants for previous unnormalized step-response Quality-Control (Now superseded by Y-correction approach)
-pub const UNNORMALIZED_MEAN_THRESHOLD_FOR_RELATIVE_STD_CHECK: f32 = 1.0;
-pub const UNNORMALIZED_RELATIVE_STD_DEV_MAX: f32 = 0.35;
-pub const UNNORMALIZED_ABSOLUTE_STD_DEV_MAX_FOR_SMALL_MEAN: f32 = 0.55;
-*/
+// Final tolerance for normalized steady-state mean in step response plot
+pub const FINAL_NORMALIZED_STEADY_STATE_TOLERANCE: f64 = 0.15;
 
 // Default setpoint threshold, can be overridden at runtime for categorizing responses
 pub const DEFAULT_SETPOINT_THRESHOLD: f64 = 500.0;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -13,30 +13,25 @@ pub const STEP_RESPONSE_PLOT_DURATION_S: f64 = 0.5;
 
 // Constants for the step response calculation method (mimicking PTstepcalc.m)
 pub const FRAME_LENGTH_S: f64 = 2.0; // Length of each window in seconds (Matlab uses 2s)
-pub const RESPONSE_LENGTH_S: f64 = 0.5; // Length of the step response to keep (500ms, matches PTstepcalc's wnd/StepRespDuration_ms)
-pub const SUPERPOSITION_FACTOR: usize = 16; // Number of overlapping windows within a frame length (can be tuned)
-pub const TUKEY_ALPHA: f64 = 1.0; // Alpha for Tukey window (1.0 is Hanning window, matches PTstepcalc)
+pub const RESPONSE_LENGTH_S: f64 = 0.5; // Length of the step response to keep (500ms)
+pub const SUPERPOSITION_FACTOR: usize = 16; // Number of overlapping windows (can be tuned)
+pub const TUKEY_ALPHA: f64 = 1.0; // Alpha for Tukey window (1.0 is Hanning window)
 
 // Initial Gyro Smoothing (applied before deconvolution)
-// 0 for no smoothing. Otherwise, window size for moving average.
-// PTstepcalc uses LOESS with variable window (e.g., 20, 40, 60 samples based on smoothFactor).
-// A simple moving average is implemented here; 10-20 might be a starting point if > 0.
-// For PTB similarity, some level of pre-smoothing is often beneficial.
-pub const INITIAL_GYRO_SMOOTHING_WINDOW: usize = 15; // Example: Set to 10 or 20 to enable, or 0 to disable
+pub const INITIAL_GYRO_SMOOTHING_WINDOW: usize = 15; // Set to 15 based on user's last test
 
-// Individual Response "Y-Correction" (Normalization before averaging, mimics PTB)
+// Individual Response "Y-Correction" (Normalization before averaging)
 pub const APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION: bool = true;
 // If Y-correction is applied, this is the minimum absolute mean of the unnormalized steady-state
 // required to attempt the correction. Prevents extreme scaling/division by near-zero.
-pub const Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS: f32 = 0.1; // Tune this threshold if needed
+pub const Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS: f32 = 0.1; // Tune this threshold if needed (0.1 is a common starting point)
 
 // Quality Control for *individually Y-corrected* (or uncorrected if Y_CORRECTION flag is false) responses
-// These values mimic PTstepcalc.m's QC: min > 0.5 && max < 3 on the (potentially) Y-corrected steady-state.
-pub const NORMALIZED_STEADY_STATE_MIN_VAL: f32 = 0.5;
-pub const NORMALIZED_STEADY_STATE_MAX_VAL: f32 = 3.0;
+// These values mimic PTstepcalc.m's QC but are applied to responses targeting 1.0.
+pub const NORMALIZED_STEADY_STATE_MIN_VAL: f32 = 0.5; // From PTB
+pub const NORMALIZED_STEADY_STATE_MAX_VAL: f32 = 3.0; // From PTB
 
 // Optional: Additional check on the mean of the Y-corrected steady-state.
-// If enabled, the mean of the Y-corrected steady state should be within these bounds.
 pub const ENABLE_NORMALIZED_STEADY_STATE_MEAN_CHECK: bool = true;
 pub const NORMALIZED_STEADY_STATE_MEAN_MIN: f32 = 0.75; // e.g., mean should be > 0.75 after Y-correction
 pub const NORMALIZED_STEADY_STATE_MEAN_MAX: f32 = 1.25; // e.g., mean should be < 1.25 after Y-correction
@@ -46,8 +41,7 @@ pub const STEADY_STATE_START_S: f64 = 0.2; // Start time for steady-state check 
 pub const STEADY_STATE_END_S: f64 = 0.5;   // End time for steady-state check (effectively to the end of RESPONSE_LENGTH_S)
 
 // Constant for post-averaging smoothing of the final step response curves.
-// This is applied in the plotting stage, after responses are averaged.
-pub const POST_AVERAGING_SMOOTHING_WINDOW: usize = 15; // Moving average window size (in samples), you set this to 15
+pub const POST_AVERAGING_SMOOTHING_WINDOW: usize = 15; // Kept at 15 as per user's last setting
 
 /*
 // Constants for previous unnormalized step-response Quality-Control (Now superseded by Y-correction approach)
@@ -60,64 +54,53 @@ pub const UNNORMALIZED_ABSOLUTE_STD_DEV_MAX_FOR_SMALL_MEAN: f32 = 0.55;
 pub const DEFAULT_SETPOINT_THRESHOLD: f64 = 500.0;
 
 // Constants for filtering data based on movement and flight phase.
-pub const MOVEMENT_THRESHOLD_DEG_S: f64 = 20.0; // Minimum setpoint/gyro magnitude for a window to be considered (from PTB/PlasmaTree)
-pub const EXCLUDE_START_S: f64 = 3.0; // Exclude this many seconds from the start of the log
-pub const EXCLUDE_END_S: f64 = 3.0; // Exclude this many seconds from the end of the log
-
+pub const MOVEMENT_THRESHOLD_DEG_S: f64 = 20.0; // Minimum setpoint/gyro magnitude (from PTB/PlasmaTree)
+pub const EXCLUDE_START_S: f64 = 3.0; // Exclude seconds from the start of the log
+pub const EXCLUDE_END_S: f64 = 3.0; // Exclude seconds from the end of the log
 
 // Constants for the spectrum plot (linear amplitude)
-pub const SPECTRUM_Y_AXIS_FLOOR: f64 = 20000.0; // Maximum amplitude for spectrum plots.
-pub const SPECTRUM_NOISE_FLOOR_HZ: f64 = 70.0; // Frequency threshold below which to ignore for dynamic Y-axis scaling
-pub const SPECTRUM_Y_AXIS_HEADROOM_FACTOR: f64 = 1.2; // Factor to extend Y-axis above the highest peak
+pub const SPECTRUM_Y_AXIS_FLOOR: f64 = 20000.0;
+pub const SPECTRUM_NOISE_FLOOR_HZ: f64 = 70.0;
+pub const SPECTRUM_Y_AXIS_HEADROOM_FACTOR: f64 = 1.2;
 pub const PEAK_LABEL_MIN_AMPLITUDE: f64 = 1000.0;
 
 // Constants for PSD plots (dB scale)
-pub const PSD_Y_AXIS_FLOOR_DB: f64 = -80.0; // A reasonable floor for PSD values in dB
-pub const PSD_Y_AXIS_HEADROOM_FACTOR_DB: f64 = 10.0; // Factor to extend Y-axis above the highest peak (in dB)
-pub const PSD_PEAK_LABEL_MIN_VALUE_DB: f64 = -60.0; // Minimum PSD value in dB for a peak to be labeled.
+pub const PSD_Y_AXIS_FLOOR_DB: f64 = -80.0;
+pub const PSD_Y_AXIS_HEADROOM_FACTOR_DB: f64 = 10.0;
+pub const PSD_PEAK_LABEL_MIN_VALUE_DB: f64 = -60.0;
 
-// Constants for Spectrogram/Heatmap plots (re-introduced)
-pub const STFT_WINDOW_DURATION_S: f64 = 0.1; // Duration of each STFT window in seconds
-pub const STFT_OVERLAP_FACTOR: f64 = 0.75; // Overlap between windows (e.g., 0.75 for 75% overlap)
-pub const HEATMAP_MIN_PSD_DB: f64 = -80.0; // Minimum PSD value in dB for heatmap color scaling
-pub const HEATMAP_MAX_PSD_DB: f64 = -10.0; // Maximum PSD value in dB for heatmap color scaling
+// Constants for Spectrogram/Heatmap plots
+pub const STFT_WINDOW_DURATION_S: f64 = 0.1;
+pub const STFT_OVERLAP_FACTOR: f64 = 0.75;
+pub const HEATMAP_MIN_PSD_DB: f64 = -80.0;
+pub const HEATMAP_MAX_PSD_DB: f64 = -10.0;
 
 // Constants for Throttle-Frequency Heatmap
-pub const THROTTLE_Y_BINS_COUNT: usize = 50; // Number of bins for the throttle (Y) axis
-pub const THROTTLE_Y_MIN_VALUE: f64 = 0.0; // Minimum throttle value for plotting range
-pub const THROTTLE_Y_MAX_VALUE: f64 = 1000.0; // Maximum throttle value for plotting range
+pub const THROTTLE_Y_BINS_COUNT: usize = 50;
+pub const THROTTLE_Y_MIN_VALUE: f64 = 0.0;
+pub const THROTTLE_Y_MAX_VALUE: f64 = 1000.0;
 
 // Constants for spectrum peak labeling
-pub const MAX_PEAKS_TO_LABEL: usize = 3; // Max number of peaks (including primary) to label on spectrum plots
-pub const MIN_SECONDARY_PEAK_RATIO: f64 = 0.05; // Secondary peak must be ≥ this linear ratio of the primary peak’s amplitude
-pub const MIN_PEAK_SEPARATION_HZ: f64 = 70.0; // Minimum frequency separation between reported peaks on spectrum plots
-// Constants for advanced peak detection
-pub const ENABLE_WINDOW_PEAK_DETECTION: bool = true; // Set to true to use window-based peak detection
-pub const PEAK_DETECTION_WINDOW_RADIUS: usize = 3;   // Radius W for peak detection window (total 2*W+1 points).
+pub const MAX_PEAKS_TO_LABEL: usize = 3;
+pub const MIN_SECONDARY_PEAK_RATIO: f64 = 0.05;
+pub const MIN_PEAK_SEPARATION_HZ: f64 = 70.0;
+pub const ENABLE_WINDOW_PEAK_DETECTION: bool = true;
+pub const PEAK_DETECTION_WINDOW_RADIUS: usize = 3;
 
-
-// --- Plot Color Assignments (Based on Screenshots) ---
-
-// PIDsum vs PID Error vs Setpoint Plot
+// --- Plot Color Assignments ---
 pub const COLOR_PIDSUM_MAIN: &RGBColor = &GREEN;
 pub const COLOR_PIDERROR_MAIN: &RGBColor = &PURPLE;
 pub const COLOR_SETPOINT_MAIN: &RGBColor = &ORANGE;
-
-// Setpoint vs Gyro Plot
 pub const COLOR_SETPOINT_VS_GYRO_SP: &RGBColor = &ORANGE;
 pub const COLOR_SETPOINT_VS_GYRO_GYRO: &RGBColor = &LIGHTBLUE;
-
-// Gyro vs Unfilt Gyro Plot
 pub const COLOR_GYRO_VS_UNFILT_FILT: &RGBColor = &LIGHTBLUE;
 pub const COLOR_GYRO_VS_UNFILT_UNFILT: &RGBColor = &AMBER;
-
-// Step Response Plot
 pub const COLOR_STEP_RESPONSE_LOW_SP: &RGBColor = &LIGHTBLUE;
 pub const COLOR_STEP_RESPONSE_HIGH_SP: &RGBColor = &ORANGE;
 pub const COLOR_STEP_RESPONSE_COMBINED: &RGBColor = &RED;
 
 // Stroke widths for lines
-pub const LINE_WIDTH_PLOT: u32 = 1; // Width for plot lines
-pub const LINE_WIDTH_LEGEND: u32 = 2; // Width for legend lines
+pub const LINE_WIDTH_PLOT: u32 = 1;
+pub const LINE_WIDTH_LEGEND: u32 = 2;
 
 // src/constants.rs

--- a/src/data_analysis/calc_step_response.rs
+++ b/src/data_analysis/calc_step_response.rs
@@ -319,4 +319,23 @@ pub fn calculate_step_response(
     Ok((response_time.mapv(|t| t as f64), valid_stacked_responses, valid_window_max_setpoints))
 }
 
+/// Finds the peak (maximum) value in a 1D response data array.
+/// Returns None if the array is empty or contains no finite values.
+pub fn find_peak_value(response_data: &Array1<f64>) -> Option<f64> {
+    if response_data.is_empty() {
+        return None;
+    }
+    let mut peak_val = f64::NEG_INFINITY;
+    let mut found_finite = false;
+    for &val in response_data.iter() {
+        if val.is_finite() {
+            if !found_finite || val > peak_val {
+                peak_val = val;
+            }
+            found_finite = true;
+        }
+    }
+    if found_finite { Some(peak_val) } else { None }
+}
+
 // src/data_analysis/calc_step_response.rs

--- a/src/data_analysis/calc_step_response.rs
+++ b/src/data_analysis/calc_step_response.rs
@@ -6,22 +6,24 @@ use std::error::Error;
 
 use crate::constants::{
     FRAME_LENGTH_S, RESPONSE_LENGTH_S, SUPERPOSITION_FACTOR, TUKEY_ALPHA,
-    INITIAL_GYRO_SMOOTHING_WINDOW, // New
-    APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION, // New
-    Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS, // New
-    NORMALIZED_STEADY_STATE_MIN_VAL, // New or re-purposed
-    NORMALIZED_STEADY_STATE_MAX_VAL, // New or re-purposed
-    ENABLE_NORMALIZED_STEADY_STATE_MEAN_CHECK, //New
-    NORMALIZED_STEADY_STATE_MEAN_MIN, // New
-    NORMALIZED_STEADY_STATE_MEAN_MAX, // New
+    INITIAL_GYRO_SMOOTHING_WINDOW,
+    APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION,
+    Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS,
+    NORMALIZED_STEADY_STATE_MIN_VAL,
+    NORMALIZED_STEADY_STATE_MAX_VAL,
+    ENABLE_NORMALIZED_STEADY_STATE_MEAN_CHECK,
+    NORMALIZED_STEADY_STATE_MEAN_MIN,
+    NORMALIZED_STEADY_STATE_MEAN_MAX,
     STEADY_STATE_START_S, STEADY_STATE_END_S,
     MOVEMENT_THRESHOLD_DEG_S,
 };
 
 use crate::data_analysis::fft_utils;
 
-// tukeywin, winstacker_contiguous, wiener_deconvolution_window, cumulative_sum are assumed to be the same as before.
-// moving_average_smooth_f32 will be a new helper for initial gyro smoothing.
+// tukeywin, winstacker_contiguous, wiener_deconvolution_window, cumulative_sum,
+// moving_average_smooth_f32, moving_average_smooth_f64, average_responses
+// are assumed to be the same as in the previous full file output provided.
+// For brevity, only calculate_step_response is shown with changes.
 
 /// Makes a Tukey window for enveloping. (Same as before)
 pub fn tukeywin(num: usize, alpha: f64) -> Array1<f32> {
@@ -62,9 +64,9 @@ fn winstacker_contiguous( input_data: &Array1<f32>, output_data: &Array1<f32>, f
 fn wiener_deconvolution_window( input_window: &Array1<f32>, output_window: &Array1<f32>, _sample_rate: f64) -> Array1<f32> {
     let n = input_window.len(); if n == 0 { return Array1::zeros(n); }
     let padded_n = n.next_power_of_two();
-    let mut input_padded_vec = vec![0.0f32; padded_n]; input_padded_vec[0..n].copy_from_slice(input_window.as_slice().unwrap());
+    let mut input_padded_vec = vec![0.0f32; padded_n]; if n > 0 {input_padded_vec[0..n].copy_from_slice(input_window.as_slice().unwrap_or_default());}
     let input_padded = Array1::from(input_padded_vec);
-    let mut output_padded_vec = vec![0.0f32; padded_n]; output_padded_vec[0..n].copy_from_slice(output_window.as_slice().unwrap());
+    let mut output_padded_vec = vec![0.0f32; padded_n]; if n > 0 {output_padded_vec[0..n].copy_from_slice(output_window.as_slice().unwrap_or_default());}
     let output_padded = Array1::from(output_padded_vec);
     let h_spec = fft_utils::fft_forward(&input_padded); let g_spec = fft_utils::fft_forward(&output_padded);
     if h_spec.is_empty() || g_spec.is_empty() || h_spec.len() != g_spec.len() { eprintln!("Warning: FFT output empty/mismatch in Wiener deconvolution."); return Array1::zeros(n); }
@@ -77,7 +79,7 @@ fn wiener_deconvolution_window( input_window: &Array1<f32>, output_window: &Arra
         else { deconvolved_spec[i] = num_complex::Complex32::new(0.0, 0.0); }
     }
     let deconvolved_impulse = fft_utils::fft_inverse(&deconvolved_spec, padded_n);
-    deconvolved_impulse.slice(s![0..n]).to_owned()
+    if n > 0 { deconvolved_impulse.slice(s![0..n]).to_owned() } else { Array1::zeros(0) }
 }
 
 /// Cumulative sum. (Same as before)
@@ -90,7 +92,7 @@ fn cumulative_sum(data: &Array1<f32>) -> Array1<f32> {
     cumulative
 }
 
-/// Applies a moving average filter to smooth a 1D array of f32. (New helper, or use existing if it matches)
+/// Applies a moving average filter to smooth a 1D array of f32. (Same as before)
 pub fn moving_average_smooth_f32(data: &Array1<f32>, window_size: usize) -> Array1<f32> {
     if window_size <= 1 || data.is_empty() {
         return data.to_owned();
@@ -107,8 +109,22 @@ pub fn moving_average_smooth_f32(data: &Array1<f32>, window_size: usize) -> Arra
     smoothed_data
 }
 
+/// Applies a moving average filter to smooth a 1D array of f64. (Same as before)
+pub fn moving_average_smooth_f64(data: &Array1<f64>, window_size: usize) -> Array1<f64> {
+    if window_size <= 1 || data.is_empty() { return data.to_owned(); }
+    let mut smoothed_data = Array1::<f64>::zeros(data.len());
+    let mut current_sum: f64 = 0.0;
+    let mut history: VecDeque<f64> = VecDeque::with_capacity(window_size);
+    for i in 0..data.len() {
+        let val = data[i]; history.push_back(val); current_sum += val;
+        if history.len() > window_size { if let Some(old_val) = history.pop_front() { current_sum -= old_val; }}
+        let current_window_len = history.len() as f64;
+        if current_window_len > 0.0 { smoothed_data[i] = current_sum / current_window_len; } else { smoothed_data[i] = 0.0; }
+    }
+    smoothed_data
+}
 
-/// Calculates the mean of the step responses (used by plotting, can remain f64 if preferred there)
+/// Calculates the mean of the step responses (used by plotting). (Same as before)
 pub fn average_responses( stacked_responses: &Array2<f32>, weights: &Array1<f32>, response_len: usize) -> Result<Array1<f64>, Box<dyn Error>> {
     let num_windows = stacked_responses.shape()[0];
     if num_windows == 0 || response_len == 0 || weights.len() != num_windows || stacked_responses.shape()[1] != response_len {
@@ -127,21 +143,21 @@ pub fn average_responses( stacked_responses: &Array2<f32>, weights: &Array1<f32>
     Ok(averaged_response)
 }
 
+
 pub fn calculate_step_response(
     _time: &Array1<f64>,
     setpoint: &Array1<f32>,
-    gyro_filtered_input: &Array1<f32>, // Renamed to avoid confusion
+    gyro_filtered_input: &Array1<f32>,
     sample_rate: f64,
 ) -> Result<(Array1<f64>, Array2<f32>, Array1<f32>), Box<dyn Error>> {
     if setpoint.is_empty() || gyro_filtered_input.is_empty() || setpoint.len() != gyro_filtered_input.len() || sample_rate <= 0.0 {
         return Err("Invalid input to calculate_step_response".into());
     }
 
-    // Step 1: Optional Initial Gyro Smoothing
     let gyro_processed = if INITIAL_GYRO_SMOOTHING_WINDOW > 1 {
         moving_average_smooth_f32(gyro_filtered_input, INITIAL_GYRO_SMOOTHING_WINDOW)
     } else {
-        gyro_filtered_input.to_owned() // Or just pass by reference if no copy needed
+        gyro_filtered_input.to_owned()
     };
 
     let frame_length_samples = (FRAME_LENGTH_S * sample_rate).ceil() as usize;
@@ -153,19 +169,14 @@ pub fn calculate_step_response(
 
     let ss_start_sample = (STEADY_STATE_START_S * sample_rate).floor() as usize;
     let ss_end_sample = (STEADY_STATE_END_S * sample_rate).ceil() as usize;
-    let effective_ss_start_sample = ss_start_sample.min(response_length_samples.saturating_sub(1)); // ensure it's a valid index
-    let effective_ss_end_sample = ss_end_sample.min(response_length_samples).max(effective_ss_start_sample + 1); // ensure end > start and within bounds
-
+    let effective_ss_start_sample = ss_start_sample.min(response_length_samples.saturating_sub(1));
+    let effective_ss_end_sample = ss_end_sample.min(response_length_samples).max(effective_ss_start_sample + 1);
 
     let mut stacked_step_responses_qc: Vec<Array1<f32>> = Vec::new();
     let mut window_max_setpoints_qc: Vec<f32> = Vec::new();
 
     let (stacked_input_raw, stacked_output_raw) = winstacker_contiguous(
-        setpoint,
-        &gyro_processed, // Use the (potentially) smoothed gyro data
-        frame_length_samples,
-        SUPERPOSITION_FACTOR,
-    );
+        setpoint, &gyro_processed, frame_length_samples, SUPERPOSITION_FACTOR);
 
     let num_windows = stacked_input_raw.shape()[0];
     if num_windows == 0 { return Err("No complete windows generated.".into()); }
@@ -177,7 +188,7 @@ pub fn calculate_step_response(
         let output_window_raw = stacked_output_raw.row(i).to_owned();
 
         let max_setpoint_in_window = input_window_raw.iter().fold(0.0f32, |max_val, &v| max_val.max(v.abs()));
-        if max_setpoint_in_window < MOVEMENT_THRESHOLD_DEG_S as f32 { // Simplified check, PTB also checks gyro
+        if max_setpoint_in_window < MOVEMENT_THRESHOLD_DEG_S as f32 {
              continue;
         }
 
@@ -185,69 +196,77 @@ pub fn calculate_step_response(
         let output_window_windowed = &output_window_raw * &window_func;
 
         let impulse_response = wiener_deconvolution_window(&input_window_windowed, &output_window_windowed, sample_rate);
-        let impulse_response_truncated = impulse_response.slice(s![0..frame_length_samples]).to_owned();
+        let impulse_response_truncated = if impulse_response.len() >= frame_length_samples {
+            impulse_response.slice(s![0..frame_length_samples]).to_owned()
+        } else {
+            // eprintln!("Warning: Impulse response too short ({} vs {}) for window {}. Skipping.", impulse_response.len(), frame_length_samples, i);
+            continue;
+        };
         if impulse_response_truncated.is_empty() { continue; }
 
         let unnormalized_step_response = cumulative_sum(&impulse_response_truncated);
         if unnormalized_step_response.len() < response_length_samples { continue; }
         let truncated_unnormalized_response = unnormalized_step_response.slice(s![0..response_length_samples]).to_owned();
 
-        let mut response_for_qc = truncated_unnormalized_response.clone(); // Start with unnormalized
-        let mut y_correction_applied_successfully = false;
+        let mut response_for_qc = truncated_unnormalized_response.clone();
+        let mut y_correction_attempted_and_valid_for_qc = false;
 
         if APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION {
             if effective_ss_start_sample < effective_ss_end_sample && truncated_unnormalized_response.len() >= effective_ss_end_sample {
                 let unnorm_ss_segment = truncated_unnormalized_response.slice(s![effective_ss_start_sample..effective_ss_end_sample]);
                 if let Some(unnorm_ss_mean) = unnorm_ss_segment.mean() {
                     if unnorm_ss_mean.is_finite() && unnorm_ss_mean.abs() > Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS {
-                        // PTB's specific scaling: val * (2 - mean)
-                        let scaling_factor = 2.0 - unnorm_ss_mean;
-                        response_for_qc = truncated_unnormalized_response.mapv(|v| v * scaling_factor);
-                        y_correction_applied_successfully = true;
+                        // ** MODIFIED: Standard Normalization for Y-Correction **
+                        response_for_qc = truncated_unnormalized_response.mapv(|v| v / unnorm_ss_mean);
+                        y_correction_attempted_and_valid_for_qc = true;
                     } else {
-                        // eprintln!("Debug: Window {} Y-correction skipped: unnormalized mean {:.2} too small or not finite.", i, unnorm_ss_mean);
+                        // Unnormalized mean is too small or not finite, Y-correction cannot be reliably applied.
+                        // Window will proceed to QC with its unnormalized response if APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION is false,
+                        // or be effectively skipped for Y-corrected QC if APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION is true
+                        // (as y_correction_attempted_and_valid_for_qc remains false).
+                    }
+                }
+            }
+        } else {
+            // If Y-correction is not applied, QC will run on the unnormalized response.
+            // The NORMALIZED_STEADY_STATE constants might not be appropriate in this case.
+            // This path assumes QC constants are set considering unnormalized data if Y-correction is off.
+            y_correction_attempted_and_valid_for_qc = true; // Allow QC to proceed on unnormalized data
+        }
+
+        // --- Quality Control ---
+        // If Y-correction is enabled, QC should only run if Y-correction was successfully applied.
+        // If Y-correction is disabled, QC runs on the unnormalized data.
+        let mut current_window_passes_qc = false;
+        if (APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION && y_correction_attempted_and_valid_for_qc) || !APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION {
+            if effective_ss_start_sample < effective_ss_end_sample && response_for_qc.len() >= effective_ss_end_sample {
+                let qc_ss_segment = response_for_qc.slice(s![effective_ss_start_sample..effective_ss_end_sample]);
+                if !qc_ss_segment.is_empty() {
+                    let min_val_ss = qc_ss_segment.iter().fold(f32::INFINITY, |a, &b| a.min(b));
+                    let max_val_ss = qc_ss_segment.iter().fold(f32::NEG_INFINITY, |a, &b| a.max(b));
+                    let mean_val_ss_opt = qc_ss_segment.mean();
+
+                    if min_val_ss.is_finite() && max_val_ss.is_finite() &&
+                       min_val_ss > NORMALIZED_STEADY_STATE_MIN_VAL && max_val_ss < NORMALIZED_STEADY_STATE_MAX_VAL {
+                        if ENABLE_NORMALIZED_STEADY_STATE_MEAN_CHECK {
+                            if let Some(mean_val_ss) = mean_val_ss_opt {
+                                if mean_val_ss.is_finite() &&
+                                   mean_val_ss > NORMALIZED_STEADY_STATE_MEAN_MIN &&
+                                   mean_val_ss < NORMALIZED_STEADY_STATE_MEAN_MAX {
+                                    current_window_passes_qc = true;
+                                }
+                            }
+                        } else {
+                            current_window_passes_qc = true;
+                        }
                     }
                 }
             }
         }
 
-        // --- Quality Control ---
-        let mut current_window_passes_qc = false;
-        if effective_ss_start_sample < effective_ss_end_sample && response_for_qc.len() >= effective_ss_end_sample {
-            let qc_ss_segment = response_for_qc.slice(s![effective_ss_start_sample..effective_ss_end_sample]);
-            if qc_ss_segment.is_empty() { // Should not happen if indices are correct
-                 eprintln!("Warning: QC steady-state segment empty for window {}. Skipping QC.", i);
-            } else {
-                let min_val_ss = qc_ss_segment.iter().fold(f32::INFINITY, |a, &b| a.min(b));
-                let max_val_ss = qc_ss_segment.iter().fold(f32::NEG_INFINITY, |a, &b| a.max(b));
-                let mean_val_ss_opt = qc_ss_segment.mean();
-
-                if min_val_ss.is_finite() && max_val_ss.is_finite() &&
-                   min_val_ss > NORMALIZED_STEADY_STATE_MIN_VAL && max_val_ss < NORMALIZED_STEADY_STATE_MAX_VAL {
-                    if ENABLE_NORMALIZED_STEADY_STATE_MEAN_CHECK {
-                        if let Some(mean_val_ss) = mean_val_ss_opt {
-                            if mean_val_ss.is_finite() &&
-                               mean_val_ss > NORMALIZED_STEADY_STATE_MEAN_MIN &&
-                               mean_val_ss < NORMALIZED_STEADY_STATE_MEAN_MAX {
-                                current_window_passes_qc = true;
-                            } else {
-                                // eprintln!("Debug: Window {} failed QC: Y-corrected mean {:.2} out of bounds ({:.2} - {:.2}).",
-                                //    i, mean_val_ss.unwrap_or(f32::NAN), NORMALIZED_STEADY_STATE_MEAN_MIN, NORMALIZED_STEADY_STATE_MEAN_MAX);
-                            }
-                        } else { /* Mean calculation failed */ }
-                    } else {
-                        current_window_passes_qc = true; // Passed min/max, and mean check is disabled
-                    }
-                } else {
-                     // eprintln!("Debug: Window {} failed QC: Y-corrected min/max ({:.2}/{:.2}) out of bounds ({:.2} - {:.2}). Applied Y-corr: {}",
-                     //    i, min_val_ss, max_val_ss, NORMALIZED_STEADY_STATE_MIN_VAL, NORMALIZED_STEADY_STATE_MAX_VAL, y_correction_applied_successfully);
-                }
-            }
-        } else { /* effective_ss window invalid or response too short */ }
-
 
         if current_window_passes_qc {
-             stacked_step_responses_qc.push(response_for_qc); // This is the (potentially) Y-corrected response
+             stacked_step_responses_qc.push(response_for_qc);
              window_max_setpoints_qc.push(max_setpoint_in_window);
         }
     }
@@ -263,24 +282,6 @@ pub fn calculate_step_response(
     let response_time = Array1::linspace(0.0, RESPONSE_LENGTH_S, response_length_samples);
 
     Ok((response_time.mapv(|t| t as f64), valid_stacked_responses, valid_window_max_setpoints))
-}
-
-
-// moving_average_smooth_f64 (for plotting) would remain the same if it's in this file,
-// or be used from where it's defined if `plot_step_response.rs` calls it.
-// For brevity, not re-listing it if it's unchanged and used elsewhere.
-pub fn moving_average_smooth_f64(data: &Array1<f64>, window_size: usize) -> Array1<f64> {
-    if window_size <= 1 || data.is_empty() { return data.to_owned(); }
-    let mut smoothed_data = Array1::<f64>::zeros(data.len());
-    let mut current_sum: f64 = 0.0;
-    let mut history: VecDeque<f64> = VecDeque::with_capacity(window_size);
-    for i in 0..data.len() {
-        let val = data[i]; history.push_back(val); current_sum += val;
-        if history.len() > window_size { if let Some(old_val) = history.pop_front() { current_sum -= old_val; }}
-        let current_window_len = history.len() as f64;
-        if current_window_len > 0.0 { smoothed_data[i] = current_sum / current_window_len; } else { smoothed_data[i] = 0.0; }
-    }
-    smoothed_data
 }
 
 // src/data_analysis/calc_step_response.rs

--- a/src/data_analysis/calc_step_response.rs
+++ b/src/data_analysis/calc_step_response.rs
@@ -1,35 +1,38 @@
-// src/step_response.rs
+// src/data_analysis/calc_step_response.rs
 
 use ndarray::{Array1, Array2, s};
 use std::collections::VecDeque;
 use std::error::Error;
 
 use crate::constants::{
-    FRAME_LENGTH_S, RESPONSE_LENGTH_S, SUPERPOSITION_FACTOR, TUKEY_ALPHA, 
-    STEADY_STATE_START_S, STEADY_STATE_END_S, STEADY_STATE_MIN_VAL, STEADY_STATE_MAX_VAL,
+    FRAME_LENGTH_S, RESPONSE_LENGTH_S, SUPERPOSITION_FACTOR, TUKEY_ALPHA,
+    INITIAL_GYRO_SMOOTHING_WINDOW, // New
+    APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION, // New
+    Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS, // New
+    NORMALIZED_STEADY_STATE_MIN_VAL, // New or re-purposed
+    NORMALIZED_STEADY_STATE_MAX_VAL, // New or re-purposed
+    ENABLE_NORMALIZED_STEADY_STATE_MEAN_CHECK, //New
+    NORMALIZED_STEADY_STATE_MEAN_MIN, // New
+    NORMALIZED_STEADY_STATE_MEAN_MAX, // New
+    STEADY_STATE_START_S, STEADY_STATE_END_S,
     MOVEMENT_THRESHOLD_DEG_S,
 };
 
 use crate::data_analysis::fft_utils;
 
+// tukeywin, winstacker_contiguous, wiener_deconvolution_window, cumulative_sum are assumed to be the same as before.
+// moving_average_smooth_f32 will be a new helper for initial gyro smoothing.
 
-/// Makes a Tukey window for enveloping.
+/// Makes a Tukey window for enveloping. (Same as before)
 pub fn tukeywin(num: usize, alpha: f64) -> Array1<f32> {
-    if alpha <= 0.0 {
-        return Array1::ones(num); // rectangular window
-    } else if alpha >= 1.0 {
-        // Hanning window is a special case of Tukey with alpha=1.0
+    if alpha <= 0.0 { return Array1::ones(num); }
+    else if alpha >= 1.0 {
         let mut window = Array1::<f32>::zeros(num);
-        for i in 0..num {
-            window[i] = 0.5 * (1.0 - (2.0 * std::f64::consts::PI * i as f64 / (num as f64 - 1.0)).cos()) as f32;
-        }
+        for i in 0..num { window[i] = 0.5 * (1.0 - (2.0 * std::f64::consts::PI * i as f64 / (num as f64 - 1.0)).cos()) as f32; }
         return window;
     }
-
     let mut window = Array1::<f32>::ones(num);
-    let alpha_half = alpha / 2.0;
-    let n_alpha = (alpha_half * (num as f64 - 1.0)).floor() as usize;
-
+    let alpha_half = alpha / 2.0; let n_alpha = (alpha_half * (num as f64 - 1.0)).floor() as usize;
     for i in 0..n_alpha {
         window[i] = 0.5 * (1.0 + (std::f64::consts::PI * i as f64 / (n_alpha as f64)).cos()) as f32;
         window[num - 1 - i] = window[i];
@@ -37,354 +40,247 @@ pub fn tukeywin(num: usize, alpha: f64) -> Array1<f32> {
     window
 }
 
-
-/// Generates overlapping windows from contiguous input data.
-/// Returns a tuple of stacked input and output windows.
-/// This version operates on contiguous data and is used internally.
-fn winstacker_contiguous(
-    input_data: &Array1<f32>,
-    output_data: &Array1<f32>,
-    frame_length_samples: usize,
-    superposition_factor: usize,
-) -> (Array2<f32>, Array2<f32>) {
+/// Generates overlapping windows. (Same as before)
+fn winstacker_contiguous( input_data: &Array1<f32>, output_data: &Array1<f32>, frame_length_samples: usize, superposition_factor: usize) -> (Array2<f32>, Array2<f32>) {
     let total_len = input_data.len();
-    if total_len == 0 || frame_length_samples == 0 || superposition_factor == 0 {
-        return (Array2::zeros((0, 0)), Array2::zeros((0, 0)));
-    }
-
+    if total_len == 0 || frame_length_samples == 0 || superposition_factor == 0 { return (Array2::zeros((0, 0)), Array2::zeros((0, 0))); }
     let shift = frame_length_samples / superposition_factor;
-    if shift == 0 {
-         eprintln!("Warning: Window shift is zero. Adjust frame_length_samples or superposition_factor.");
-         return (Array2::zeros((0, 0)), Array2::zeros((0, 0)));
-    }
-
-    // Calculate the number of windows that can fit entirely within the data
-    let num_windows = if total_len >= frame_length_samples {
-        (total_len - frame_length_samples) / shift + 1
-    } else {
-        0
-    };
-
-
-    if num_windows == 0 {
-        return (Array2::zeros((0, 0)), Array2::zeros((0, 0)));
-    }
-
+    if shift == 0 { eprintln!("Warning: Window shift is zero."); return (Array2::zeros((0, 0)), Array2::zeros((0, 0))); }
+    let num_windows = if total_len >= frame_length_samples { (total_len - frame_length_samples) / shift + 1 } else { 0 };
+    if num_windows == 0 { return (Array2::zeros((0, 0)), Array2::zeros((0, 0))); }
     let mut stacked_input = Array2::<f32>::zeros((num_windows, frame_length_samples));
     let mut stacked_output = Array2::<f32>::zeros((num_windows, frame_length_samples));
-
     for i in 0..num_windows {
-        let start = i * shift;
-        let end = start + frame_length_samples;
-        // The check `end <= total_len` is implicitly handled by `num_windows` calculation
+        let start = i * shift; let end = start + frame_length_samples;
         stacked_input.row_mut(i).assign(&input_data.slice(s![start..end]));
         stacked_output.row_mut(i).assign(&output_data.slice(s![start..end]));
     }
-
     (stacked_input, stacked_output)
 }
 
-/// Performs Wiener deconvolution on a single input/output window.
-/// Returns the deconvolved impulse response.
-fn wiener_deconvolution_window(
-    input_window: &Array1<f32>,
-    output_window: &Array1<f32>,
-    _sample_rate: f64, // Sample rate is not directly used in this function, but kept for signature consistency if needed later
-) -> Array1<f32> {
-    let n = input_window.len();
-    if n == 0 {
-        return Array1::zeros(n);
-    }
-
-    // Pad to next power of 2 for efficient FFT
+/// Wiener deconvolution. (Same as before)
+fn wiener_deconvolution_window( input_window: &Array1<f32>, output_window: &Array1<f32>, _sample_rate: f64) -> Array1<f32> {
+    let n = input_window.len(); if n == 0 { return Array1::zeros(n); }
     let padded_n = n.next_power_of_two();
-    let input_padded = {
-        let mut padded = Array1::<f32>::zeros(padded_n);
-        padded.slice_mut(s![0..n]).assign(input_window);
-        padded
-    };
-    let mut output_padded = Array1::<f32>::zeros(padded_n);
-    output_padded.slice_mut(s![0..n]).assign(output_window);
-
-
-    let h_spec = fft_utils::fft_forward(&input_padded); // Use fft_utils
-    let g_spec = fft_utils::fft_forward(&output_padded); // Use fft_utils
-
-    if h_spec.is_empty() || g_spec.is_empty() || h_spec.len() != g_spec.len() {
-         eprintln!("Warning: FFT output empty or length mismatch in Wiener deconvolution.");
-         return Array1::zeros(n);
-    }
-
-    // Use a small constant regularization term (from PTstepcalc.m 0.0001)
-    let regularization_term = 0.0001;
-    let epsilon = 1e-9; // Small value to prevent division by zero
-
-    let mut deconvolved_spec = Array1::<num_complex::Complex32>::zeros(h_spec.len()); // Use num_complex::Complex32 explicitly
-
+    let mut input_padded_vec = vec![0.0f32; padded_n]; input_padded_vec[0..n].copy_from_slice(input_window.as_slice().unwrap());
+    let input_padded = Array1::from(input_padded_vec);
+    let mut output_padded_vec = vec![0.0f32; padded_n]; output_padded_vec[0..n].copy_from_slice(output_window.as_slice().unwrap());
+    let output_padded = Array1::from(output_padded_vec);
+    let h_spec = fft_utils::fft_forward(&input_padded); let g_spec = fft_utils::fft_forward(&output_padded);
+    if h_spec.is_empty() || g_spec.is_empty() || h_spec.len() != g_spec.len() { eprintln!("Warning: FFT output empty/mismatch in Wiener deconvolution."); return Array1::zeros(n); }
+    let regularization_term = 0.0001; let epsilon = 1e-9;
+    let mut deconvolved_spec = Array1::<num_complex::Complex32>::zeros(h_spec.len());
     for i in 0..h_spec.len() {
-        let h = h_spec[i];
-        let g = g_spec[i];
-        let h_conj = h.conj();
-
-        // Wiener filter formula: G * H* / (|H|^2 + regularization_term)
+        let h = h_spec[i]; let g = g_spec[i]; let h_conj = h.conj();
         let denominator = (h * h_conj).re + regularization_term;
-
-        if denominator.abs() > epsilon {
-            deconvolved_spec[i] = (g * h_conj) / denominator;
-        } else {
-            deconvolved_spec[i] = num_complex::Complex32::new(0.0, 0.0); // Use num_complex::Complex32 explicitly
-        }
+        if denominator.abs() > epsilon { deconvolved_spec[i] = (g * h_conj) / denominator; }
+        else { deconvolved_spec[i] = num_complex::Complex32::new(0.0, 0.0); }
     }
-
-    // Perform inverse FFT and truncate to original length
-    let deconvolved_impulse = fft_utils::fft_inverse(&deconvolved_spec, padded_n); // Use fft_utils
-
-    // Return the impulse response truncated to the original window length
+    let deconvolved_impulse = fft_utils::fft_inverse(&deconvolved_spec, padded_n);
     deconvolved_impulse.slice(s![0..n]).to_owned()
 }
 
-
-/// Calculates the cumulative sum of an array to get the step response from impulse response.
+/// Cumulative sum. (Same as before)
 fn cumulative_sum(data: &Array1<f32>) -> Array1<f32> {
-    let mut cumulative = Array1::<f32>::zeros(data.len());
-    let mut current_sum = 0.0;
+    let mut cumulative = Array1::<f32>::zeros(data.len()); let mut current_sum = 0.0;
     for (i, &val) in data.iter().enumerate() {
-        if val.is_finite() {
-            current_sum += val;
-        } else {
-             eprintln!("Warning: Non-finite value ({}) detected in impulse response at index {}. Skipping.", val, i);
-        }
+        if val.is_finite() { current_sum += val; } else { eprintln!("Warning: Non-finite impulse value ({}) at index {}.", val, i); }
         cumulative[i] = current_sum;
     }
     cumulative
 }
 
-/// Applies a moving average filter to smooth a 1D array of f64.
-pub fn moving_average_smooth_f64(data: &Array1<f64>, window_size: usize) -> Array1<f64> {
+/// Applies a moving average filter to smooth a 1D array of f32. (New helper, or use existing if it matches)
+pub fn moving_average_smooth_f32(data: &Array1<f32>, window_size: usize) -> Array1<f32> {
     if window_size <= 1 || data.is_empty() {
-        return data.to_owned(); // No smoothing needed or possible.
+        return data.to_owned();
     }
-
-    let mut smoothed_data = Array1::<f64>::zeros(data.len());
-    let mut current_sum: f64 = 0.0;
-    let mut history: VecDeque<f64> = VecDeque::with_capacity(window_size);
-
+    let mut smoothed_data = Array1::<f32>::zeros(data.len());
+    let mut current_sum: f32 = 0.0;
+    let mut history: VecDeque<f32> = VecDeque::with_capacity(window_size);
     for i in 0..data.len() {
-        let val = data[i];
-        history.push_back(val);
-        current_sum += val;
-
-        if history.len() > window_size {
-            if let Some(old_val) = history.pop_front() {
-                current_sum -= old_val;
-            }
-        }
-
-        let current_window_len = history.len() as f64;
-        if current_window_len > 0.0 {
-            smoothed_data[i] = current_sum / current_window_len;
-        } else {
-            smoothed_data[i] = 0.0;
-        }
+        let val = data[i]; history.push_back(val); current_sum += val;
+        if history.len() > window_size { if let Some(old_val) = history.pop_front() { current_sum -= old_val; }}
+        let current_window_len = history.len() as f32;
+        if current_window_len > 0.0 { smoothed_data[i] = current_sum / current_window_len; } else { smoothed_data[i] = 0.0; }
     }
     smoothed_data
 }
 
 
-/// Calculates the mean of the step responses from the stacked windows,
-/// considering only windows with a weight > 0.
-/// Returns the averaged step response curve.
-/// This replaces the histogram-based mode averaging with a simpler mean.
-pub fn average_responses( // Renamed from weighted_mode_avr
-    stacked_responses: &Array2<f32>, // Stack of step responses (windows x time)
-    weights: &Array1<f32>, // Weight for each window (0.0 or 1.0 based on mask)
-    response_len: usize, // Length of the response (number of time points)
-) -> Result<Array1<f64>, Box<dyn Error>> { // Returns the averaged response curve (Array1<f64>)
+/// Calculates the mean of the step responses (used by plotting, can remain f64 if preferred there)
+pub fn average_responses( stacked_responses: &Array2<f32>, weights: &Array1<f32>, response_len: usize) -> Result<Array1<f64>, Box<dyn Error>> {
     let num_windows = stacked_responses.shape()[0];
-
     if num_windows == 0 || response_len == 0 || weights.len() != num_windows || stacked_responses.shape()[1] != response_len {
         return Err("Input data mismatch for average_responses".into());
     }
-
     let mut averaged_response = Array1::<f64>::zeros(response_len);
-    let mut active_window_counts = Array1::<f64>::zeros(response_len); // Count how many weighted windows contribute to each time point
-
-    for i in 0..num_windows { // Iterate over windows
-        let weight = weights[i] as f64;
-        if weight <= 1e-9 { continue; } // Skip windows with near-zero weight
-
-        for j in 0..response_len { // Iterate over time points in the response
+    let mut active_window_counts = Array1::<f64>::zeros(response_len);
+    for i in 0..num_windows {
+        let weight = weights[i] as f64; if weight <= 1e-9 { continue; }
+        for j in 0..response_len {
             let response_value = stacked_responses[[i, j]] as f64;
-
-            if response_value.is_finite() {
-                 // Add the value to the sum for this time point
-                 averaged_response[j] += response_value * weight; // Apply weight (currently 0 or 1)
-                 active_window_counts[j] += weight; // Count active windows (currently 0 or 1)
-            }
+            if response_value.is_finite() { averaged_response[j] += response_value * weight; active_window_counts[j] += weight; }
         }
     }
-
-    // Divide the sum by the count of active windows for each time point to get the mean
-    for j in 0..response_len {
-        if active_window_counts[j] > 1e-9 { // Avoid division by zero
-            averaged_response[j] /= active_window_counts[j];
-        } else {
-            // If no active windows contributed to this time point, leave it as 0.0 (or handle differently if needed)
-        }
-    }
-
+    for j in 0..response_len { if active_window_counts[j] > 1e-9 { averaged_response[j] /= active_window_counts[j]; } }
     Ok(averaged_response)
 }
 
-
-/// Calculates the system's step response using windowing and deconvolution,
-/// returning the stacked, quality-controlled step responses and their corresponding
-/// max setpoints for later averaging.
-/// Input: Contiguous time, setpoint, and gyro data within the analysis range, sample rate.
-/// Output: Tuple of (response_time, stacked_qc_responses, qc_window_max_setpoints) or an error.
-/// Note: The responses returned here are UN-NORMALIZED. Averaging and final normalization happen in main.rs.
 pub fn calculate_step_response(
-    _time: &Array1<f64>, // Time data is not used directly in this function, but kept for signature consistency
-    setpoint: &Array1<f32>, // Contiguous setpoint data within analysis range
-    gyro_filtered: &Array1<f32>, // Contiguous gyro data within analysis range
+    _time: &Array1<f64>,
+    setpoint: &Array1<f32>,
+    gyro_filtered_input: &Array1<f32>, // Renamed to avoid confusion
     sample_rate: f64,
 ) -> Result<(Array1<f64>, Array2<f32>, Array1<f32>), Box<dyn Error>> {
-    if setpoint.is_empty() || gyro_filtered.is_empty() || setpoint.len() != gyro_filtered.len() || sample_rate <= 0.0 {
-        return Err("Invalid input to calculate_step_response: Empty data, length mismatch, or invalid sample rate.".into());
+    if setpoint.is_empty() || gyro_filtered_input.is_empty() || setpoint.len() != gyro_filtered_input.len() || sample_rate <= 0.0 {
+        return Err("Invalid input to calculate_step_response".into());
     }
 
-    // Calculate window lengths in samples.
+    // Step 1: Optional Initial Gyro Smoothing
+    let gyro_processed = if INITIAL_GYRO_SMOOTHING_WINDOW > 1 {
+        moving_average_smooth_f32(gyro_filtered_input, INITIAL_GYRO_SMOOTHING_WINDOW)
+    } else {
+        gyro_filtered_input.to_owned() // Or just pass by reference if no copy needed
+    };
+
     let frame_length_samples = (FRAME_LENGTH_S * sample_rate).ceil() as usize;
     let response_length_samples = (RESPONSE_LENGTH_S * sample_rate).ceil() as usize;
 
     if frame_length_samples == 0 || response_length_samples == 0 {
-         return Err("Calculated window length is zero. Adjust constants or sample rate.".into());
+         return Err("Calculated window length is zero.".into());
     }
 
-    // Calculate steady-state window indices for quality control
     let ss_start_sample = (STEADY_STATE_START_S * sample_rate).floor() as usize;
     let ss_end_sample = (STEADY_STATE_END_S * sample_rate).ceil() as usize;
-    let ss_start_sample = ss_start_sample.min(response_length_samples);
-    let ss_end_sample = ss_end_sample.min(response_length_samples);
+    let effective_ss_start_sample = ss_start_sample.min(response_length_samples.saturating_sub(1)); // ensure it's a valid index
+    let effective_ss_end_sample = ss_end_sample.min(response_length_samples).max(effective_ss_start_sample + 1); // ensure end > start and within bounds
 
-    if ss_start_sample >= ss_end_sample {
-         eprintln!("Warning: Steady-state window for quality control is invalid (start >= end). Quality control based on steady-state value will be skipped.");
-    }
 
-    // Prepare storage for step responses from each window that pass quality control.
     let mut stacked_step_responses_qc: Vec<Array1<f32>> = Vec::new();
-    let mut window_max_setpoints_qc: Vec<f32> = Vec::new(); // Store max setpoint for QC windows
+    let mut window_max_setpoints_qc: Vec<f32> = Vec::new();
 
-
-    // 1. Generate overlapping windows from the contiguous data.
     let (stacked_input_raw, stacked_output_raw) = winstacker_contiguous(
         setpoint,
-        gyro_filtered,
+        &gyro_processed, // Use the (potentially) smoothed gyro data
         frame_length_samples,
         SUPERPOSITION_FACTOR,
     );
 
     let num_windows = stacked_input_raw.shape()[0];
-    if num_windows == 0 {
-        return Err("No complete windows could be generated from contiguous data.".into());
-    }
+    if num_windows == 0 { return Err("No complete windows generated.".into()); }
 
-    // Apply window function (e.g., Hanning) once
     let window_func = tukeywin(frame_length_samples, TUKEY_ALPHA);
 
-    // Process each window
     for i in 0..num_windows {
         let input_window_raw = stacked_input_raw.row(i).to_owned();
         let output_window_raw = stacked_output_raw.row(i).to_owned();
 
-        // --- Movement Threshold Check (applied to the raw window) ---
         let max_setpoint_in_window = input_window_raw.iter().fold(0.0f32, |max_val, &v| max_val.max(v.abs()));
-        let max_gyro_in_window = output_window_raw.iter().fold(0.0f32, |max_val, &v| max_val.max(v.abs()));
-
-        if max_setpoint_in_window < MOVEMENT_THRESHOLD_DEG_S as f32 && max_gyro_in_window < MOVEMENT_THRESHOLD_DEG_S as f32 {
-             // Window does not contain significant movement, skip deconvolution and QC
+        if max_setpoint_in_window < MOVEMENT_THRESHOLD_DEG_S as f32 { // Simplified check, PTB also checks gyro
              continue;
         }
 
-        // Apply window function
         let input_window_windowed = &input_window_raw * &window_func;
         let output_window_windowed = &output_window_raw * &window_func;
 
-        // 2. Perform Wiener deconvolution and cumulative sum for this window.
-        let impulse_response = wiener_deconvolution_window(
-            &input_window_windowed,
-            &output_window_windowed,
-            sample_rate,
-        );
-
-        // Truncate impulse response to frame length before cumulative sum
-        // Note: wiener_deconvolution_window already returns truncated to input length, but an explicit slice ensures length
+        let impulse_response = wiener_deconvolution_window(&input_window_windowed, &output_window_windowed, sample_rate);
         let impulse_response_truncated = impulse_response.slice(s![0..frame_length_samples]).to_owned();
+        if impulse_response_truncated.is_empty() { continue; }
 
-        if impulse_response_truncated.is_empty() || impulse_response_truncated.len() != frame_length_samples {
-             eprintln!("Warning: Truncated impulse response length mismatch for window {}. Skipping.", i);
-             continue;
-        }
+        let unnormalized_step_response = cumulative_sum(&impulse_response_truncated);
+        if unnormalized_step_response.len() < response_length_samples { continue; }
+        let truncated_unnormalized_response = unnormalized_step_response.slice(s![0..response_length_samples]).to_owned();
 
-        let step_response = cumulative_sum(&impulse_response_truncated);
+        let mut response_for_qc = truncated_unnormalized_response.clone(); // Start with unnormalized
+        let mut y_correction_applied_successfully = false;
 
-        // Truncate the step response to the desired response length *before* QC check
-        if step_response.len() < response_length_samples {
-             eprintln!("Warning: Step response shorter than response_length_samples for window {}. Skipping.", i);
-             continue;
-        }
-        let truncated_step_response = step_response.slice(s![0..response_length_samples]).to_owned();
-
-
-        // --- Individual Response Quality Control (based on steady-state value range) ---
-        let mut passes_qc = false;
-        if ss_start_sample < ss_end_sample { // Only perform QC if steady-state window is valid
-            let steady_state_segment = truncated_step_response.slice(s![ss_start_sample..ss_end_sample]);
-
-            // Use .mean() from ndarray
-            if let Some(steady_state_mean) = steady_state_segment.mean() {
-                 // Check if the UN-NORMALIZED steady-state mean is within the acceptable range
-                 if steady_state_mean.is_finite() && steady_state_mean >= STEADY_STATE_MIN_VAL as f32 && steady_state_mean <= STEADY_STATE_MAX_VAL as f32 {
-                     passes_qc = true; // Window passes QC based on steady-state value range
-                 } else {
-                     // Optionally print why a window failed QC
-                     // eprintln!("Debug: Window {} failed QC. Steady-state mean: {:.2}", i, steady_state_mean.unwrap_or(f32::NAN));
-                 }
-            } else {
-                 eprintln!("Warning: Could not calculate steady-state mean for window {}. Skipping QC.", i);
+        if APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION {
+            if effective_ss_start_sample < effective_ss_end_sample && truncated_unnormalized_response.len() >= effective_ss_end_sample {
+                let unnorm_ss_segment = truncated_unnormalized_response.slice(s![effective_ss_start_sample..effective_ss_end_sample]);
+                if let Some(unnorm_ss_mean) = unnorm_ss_segment.mean() {
+                    if unnorm_ss_mean.is_finite() && unnorm_ss_mean.abs() > Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS {
+                        // PTB's specific scaling: val * (2 - mean)
+                        let scaling_factor = 2.0 - unnorm_ss_mean;
+                        response_for_qc = truncated_unnormalized_response.mapv(|v| v * scaling_factor);
+                        y_correction_applied_successfully = true;
+                    } else {
+                        // eprintln!("Debug: Window {} Y-correction skipped: unnormalized mean {:.2} too small or not finite.", i, unnorm_ss_mean);
+                    }
+                }
             }
-        } else {
-             // If steady-state window is invalid, skip this QC check but still require movement threshold
-             passes_qc = true; // Assume QC passes if steady-state window is invalid
         }
 
+        // --- Quality Control ---
+        let mut current_window_passes_qc = false;
+        if effective_ss_start_sample < effective_ss_end_sample && response_for_qc.len() >= effective_ss_end_sample {
+            let qc_ss_segment = response_for_qc.slice(s![effective_ss_start_sample..effective_ss_end_sample]);
+            if qc_ss_segment.is_empty() { // Should not happen if indices are correct
+                 eprintln!("Warning: QC steady-state segment empty for window {}. Skipping QC.", i);
+            } else {
+                let min_val_ss = qc_ss_segment.iter().fold(f32::INFINITY, |a, &b| a.min(b));
+                let max_val_ss = qc_ss_segment.iter().fold(f32::NEG_INFINITY, |a, &b| a.max(b));
+                let mean_val_ss_opt = qc_ss_segment.mean();
 
-        if passes_qc {
-             // Push the UN-NORMALIZED truncated response
-             stacked_step_responses_qc.push(truncated_step_response);
-             // Store the max setpoint from the *raw* window
+                if min_val_ss.is_finite() && max_val_ss.is_finite() &&
+                   min_val_ss > NORMALIZED_STEADY_STATE_MIN_VAL && max_val_ss < NORMALIZED_STEADY_STATE_MAX_VAL {
+                    if ENABLE_NORMALIZED_STEADY_STATE_MEAN_CHECK {
+                        if let Some(mean_val_ss) = mean_val_ss_opt {
+                            if mean_val_ss.is_finite() &&
+                               mean_val_ss > NORMALIZED_STEADY_STATE_MEAN_MIN &&
+                               mean_val_ss < NORMALIZED_STEADY_STATE_MEAN_MAX {
+                                current_window_passes_qc = true;
+                            } else {
+                                // eprintln!("Debug: Window {} failed QC: Y-corrected mean {:.2} out of bounds ({:.2} - {:.2}).",
+                                //    i, mean_val_ss.unwrap_or(f32::NAN), NORMALIZED_STEADY_STATE_MEAN_MIN, NORMALIZED_STEADY_STATE_MEAN_MAX);
+                            }
+                        } else { /* Mean calculation failed */ }
+                    } else {
+                        current_window_passes_qc = true; // Passed min/max, and mean check is disabled
+                    }
+                } else {
+                     // eprintln!("Debug: Window {} failed QC: Y-corrected min/max ({:.2}/{:.2}) out of bounds ({:.2} - {:.2}). Applied Y-corr: {}",
+                     //    i, min_val_ss, max_val_ss, NORMALIZED_STEADY_STATE_MIN_VAL, NORMALIZED_STEADY_STATE_MAX_VAL, y_correction_applied_successfully);
+                }
+            }
+        } else { /* effective_ss window invalid or response too short */ }
+
+
+        if current_window_passes_qc {
+             stacked_step_responses_qc.push(response_for_qc); // This is the (potentially) Y-corrected response
              window_max_setpoints_qc.push(max_setpoint_in_window);
         }
     }
 
-
-    let num_qc_windows = stacked_step_responses_qc.len();
-    if num_qc_windows == 0 {
-        return Err("No windows passed movement threshold and quality control.".into());
+    if stacked_step_responses_qc.is_empty() {
+        return Err("No windows passed quality control.".into());
     }
 
-    // Convert Vec<Array1> to Array2 for averaging
-    let valid_stacked_responses = Array2::from_shape_fn((num_qc_windows, response_length_samples), |(i, j)| {
-        stacked_step_responses_qc[i][j]
+    let valid_stacked_responses = Array2::from_shape_fn((stacked_step_responses_qc.len(), response_length_samples), |(r, c)| {
+        stacked_step_responses_qc[r][c]
     });
     let valid_window_max_setpoints = Array1::from(window_max_setpoints_qc);
-
-    // Time vector for the response plot (0 to RESPONSE_LENGTH_S).
     let response_time = Array1::linspace(0.0, RESPONSE_LENGTH_S, response_length_samples);
 
-
-    // Return the time vector, stacked QC responses, and max setpoints
     Ok((response_time.mapv(|t| t as f64), valid_stacked_responses, valid_window_max_setpoints))
 }
 
-// src/step_response.rs
+
+// moving_average_smooth_f64 (for plotting) would remain the same if it's in this file,
+// or be used from where it's defined if `plot_step_response.rs` calls it.
+// For brevity, not re-listing it if it's unchanged and used elsewhere.
+pub fn moving_average_smooth_f64(data: &Array1<f64>, window_size: usize) -> Array1<f64> {
+    if window_size <= 1 || data.is_empty() { return data.to_owned(); }
+    let mut smoothed_data = Array1::<f64>::zeros(data.len());
+    let mut current_sum: f64 = 0.0;
+    let mut history: VecDeque<f64> = VecDeque::with_capacity(window_size);
+    for i in 0..data.len() {
+        let val = data[i]; history.push_back(val); current_sum += val;
+        if history.len() > window_size { if let Some(old_val) = history.pop_front() { current_sum -= old_val; }}
+        let current_window_len = history.len() as f64;
+        if current_window_len > 0.0 { smoothed_data[i] = current_sum / current_window_len; } else { smoothed_data[i] = 0.0; }
+    }
+    smoothed_data
+}
+
+// src/data_analysis/calc_step_response.rs

--- a/src/plot_functions/plot_step_response.rs
+++ b/src/plot_functions/plot_step_response.rs
@@ -144,25 +144,31 @@ pub fn plot_step_response(
                 let final_combined_response = process_response(&combined_mask, valid_stacked_responses, response_length_samples, current_ss_start_idx, current_ss_end_idx, post_averaging_smoothing_window);
 
                 if let Some(resp) = final_low_response {
+                    let peak_val_opt = calc_step_response::find_peak_value(&resp);
+                    let peak_str = peak_val_opt.map_or_else(|| "N/A".to_string(), |p| format!("{:.2}", p));
                     series.push(PlotSeries {
                         data: response_time.iter().zip(resp.iter()).map(|(&t, &v)| (t, v)).collect(),
-                        label: format!("< {} deg/s", setpoint_threshold),
+                        label: format!("< {} deg/s (Peak: {})", setpoint_threshold, peak_str),
                         color: color_low_sp,
                         stroke_width: line_stroke_plot,
                     });
                 }
                 if let Some(resp) = final_high_response {
+                    let peak_val_opt = calc_step_response::find_peak_value(&resp);
+                    let peak_str = peak_val_opt.map_or_else(|| "N/A".to_string(), |p| format!("{:.2}", p));
                     series.push(PlotSeries {
                         data: response_time.iter().zip(resp.iter()).map(|(&t, &v)| (t, v)).collect(),
-                        label: format!("\u{2265} {} deg/s", setpoint_threshold),
+                        label: format!("\u{2265} {} deg/s (Peak: {})", setpoint_threshold, peak_str),
                         color: color_high_sp,
                         stroke_width: line_stroke_plot,
                     });
                 }
                 if let Some(resp) = final_combined_response {
+                    let peak_val_opt = calc_step_response::find_peak_value(&resp);
+                    let peak_str = peak_val_opt.map_or_else(|| "N/A".to_string(), |p| format!("{:.2}", p));
                      series.push(PlotSeries {
                         data: response_time.iter().zip(resp.iter()).map(|(&t, &v)| (t, v)).collect(),
-                        label: "Combined".to_string(), // This is the average of all Y-corrected & QC'd responses
+                        label: format!("Combined (Peak: {})", peak_str), // This is the average of all Y-corrected & QC'd responses
                         color: color_combined,
                         stroke_width: line_stroke_plot,
                     });

--- a/src/plot_functions/plot_step_response.rs
+++ b/src/plot_functions/plot_step_response.rs
@@ -9,7 +9,10 @@ use crate::constants::{
     STEP_RESPONSE_PLOT_DURATION_S,
     POST_AVERAGING_SMOOTHING_WINDOW, STEADY_STATE_START_S, STEADY_STATE_END_S,
     COLOR_STEP_RESPONSE_LOW_SP, COLOR_STEP_RESPONSE_HIGH_SP, COLOR_STEP_RESPONSE_COMBINED,
-    LINE_WIDTH_PLOT, // Added MOVEMENT_THRESHOLD_DEG_S
+    LINE_WIDTH_PLOT, MOVEMENT_THRESHOLD_DEG_S,
+    // Assume you add this to constants.rs or use an existing suitable one:
+    // pub const FINAL_NORMALIZED_STEADY_STATE_TOLERANCE: f64 = 0.15;
+    // For now, I'll use a local const as an example if it's not in your constants.rs yet.
 };
 use crate::data_analysis::calc_step_response; // For average_responses and moving_average_smooth_f64
 
@@ -21,19 +24,25 @@ pub fn plot_step_response(
     has_nonzero_f_term_data: &[bool; 3],
     setpoint_threshold: f64,
     show_legend: bool,
+    // Add axis_index_for_debug if you uncomment debug prints in process_response
+    // axis_index_for_debug: usize, // Uncomment if using debug prints
 ) -> Result<(), Box<dyn Error>> {
     let step_response_plot_duration_s = STEP_RESPONSE_PLOT_DURATION_S;
-    let steady_state_start_s = STEADY_STATE_START_S;
-    let steady_state_end_s = STEADY_STATE_END_S;
-    let post_averaging_smoothing_window = POST_AVERAGING_SMOOTHING_WINDOW;
+    let steady_state_start_s_const = STEADY_STATE_START_S; // from constants
+    let steady_state_end_s_const = STEADY_STATE_END_S;     // from constants
+    let post_averaging_smoothing_window = POST_AVERAGING_SMOOTHING_WINDOW; // from constants
     let color_high_sp: RGBColor = *COLOR_STEP_RESPONSE_HIGH_SP;
     let color_combined: RGBColor = *COLOR_STEP_RESPONSE_COMBINED;
     let color_low_sp: RGBColor = *COLOR_STEP_RESPONSE_LOW_SP;
     let line_stroke_plot = LINE_WIDTH_PLOT;
 
+    // Example for the final tolerance, ideally this comes from constants.rs
+    const FINAL_NORMALIZED_STEADY_STATE_TOLERANCE: f64 = 0.15;
+
+
     let output_file_step = format!("{}_step_response_stacked_plot_{}s.png", root_name, step_response_plot_duration_s);
     let plot_type_name = "Step Response";
-    let sr = sample_rate.unwrap_or(1000.0);
+    let sr = sample_rate.unwrap_or(1000.0); // Default sample rate if not provided
 
     let mut plot_data_per_axis: [Option<(String, std::ops::Range<f64>, std::ops::Range<f64>, Vec<PlotSeries>, String, String)>; 3] = Default::default();
 
@@ -45,13 +54,19 @@ pub fn plot_step_response(
             }
 
             let num_qc_windows = valid_stacked_responses.shape()[0];
-            let ss_start_sample = (steady_state_start_s * sr).floor() as usize;
-            let ss_end_sample = (steady_state_end_s * sr).ceil() as usize;
-            let current_ss_start_sample = ss_start_sample.min(response_length_samples);
-            let current_ss_end_sample = ss_end_sample.min(response_length_samples);
 
-            if current_ss_start_sample >= current_ss_end_sample {
-                eprintln!("Warning: Axis {} Step Response: Steady-state window is invalid (start >= end). Skipping final normalization and plot for this axis.", axis_index);
+            // Calculate steady-state window indices for this specific response_time array
+            let ss_start_idx = (steady_state_start_s_const * sr).floor() as usize;
+            let ss_end_idx = (steady_state_end_s_const * sr).ceil() as usize;
+
+            // Ensure indices are within bounds of the response_length_samples
+            let current_ss_start_idx = ss_start_idx.min(response_length_samples.saturating_sub(1));
+            let current_ss_end_idx = ss_end_idx.min(response_length_samples).max(current_ss_start_idx + 1);
+
+
+            if current_ss_start_idx >= current_ss_end_idx {
+                eprintln!("Warning: Axis {} Step Response: Steady-state window is invalid (start_idx {} >= end_idx {} for response length {}). Skipping final normalization and plot for this axis.",
+                    axis_index, current_ss_start_idx, current_ss_end_idx, response_length_samples);
                  continue;
             }
 
@@ -62,43 +77,79 @@ pub fn plot_step_response(
             let process_response = |
                 mask: &Array1<f32>,
                 stacked_resp: &Array2<f32>,
-                resp_len_samples: usize,
-                ss_start_idx: usize,
-                ss_end_idx: usize,
+                resp_len_samples_local: usize, // Use a local variable for clarity
+                ss_start_idx_local: usize,
+                ss_end_idx_local: usize,
                 smoothing_window: usize,
             | -> Option<Array1<f64>> {
-                if !mask.iter().any(|&w| w > 0.0) { return None; }
-                calc_step_response::average_responses(stacked_resp, mask, resp_len_samples)
+                if !mask.iter().any(|&w| w > 0.0) { return None; } // No windows selected by mask
+
+                // avg_resp is now an average of *individually Y-corrected* (mostly normalized towards 1) responses
+                // from calc_step_response.rs
+                calc_step_response::average_responses(stacked_resp, mask, resp_len_samples_local)
                     .ok()
                     .and_then(|avg_resp| {
                          if avg_resp.is_empty() { return None; }
+
                          let smoothed_resp = calc_step_response::moving_average_smooth_f64(&avg_resp, smoothing_window);
                          if smoothed_resp.is_empty() { return None; }
+
+                         // Shift the response to start at 0.0
                          let mut shifted_response = smoothed_resp;
-                         let first_val = shifted_response[0];
-                         shifted_response.mapv_inplace(|v| v - first_val);
-                         let steady_state_segment = shifted_response.slice(s![ss_start_idx..ss_end_idx]);
+                         if !shifted_response.is_empty() {
+                             let first_val = shifted_response[0];
+                             shifted_response.mapv_inplace(|v| v - first_val);
+                         } else {
+                             return None; // Should not happen if smoothed_resp wasn't empty
+                         }
+
+                         // This steady_state_segment is from the averaged, Y-corrected (upstream),
+                         // smoothed, and shifted response. Its mean is used for a final normalization refinement.
+                         let steady_state_segment = shifted_response.slice(s![ss_start_idx_local..ss_end_idx_local]);
+                         if steady_state_segment.is_empty() { // Guard against empty slice
+                            // eprintln!("Debug: Axis {} steady_state_segment for final norm is empty. Start: {}, End: {}, Len: {}", axis_index, ss_start_idx_local, ss_end_idx_local, shifted_response.len());
+                            return None;
+                         }
+
                          steady_state_segment.mean()
-                            .and_then(|steady_state_mean| {
-                                 if steady_state_mean.abs() > 1e-9 {
-                                      let normalized_response = shifted_response.mapv(|v| v / steady_state_mean);
-                                      normalized_response.slice(s![ss_start_idx..ss_end_idx]).mean()
-                                        .and_then(|normalized_ss_mean| {
-                                            const STEADY_STATE_TOLERANCE: f64 = 0.2;
-                                             if (normalized_ss_mean - 1.0).abs() <= STEADY_STATE_TOLERANCE {
+                            .and_then(|final_ss_mean_for_norm| {
+                                 if final_ss_mean_for_norm.abs() > 1e-9 { // Avoid division by zero
+                                      // This final normalization step ensures the plotted response aims for 1.0.
+                                      // It refines the average of the Y-corrected individual responses.
+                                      let normalized_response = shifted_response.mapv(|v| v / final_ss_mean_for_norm);
+
+                                      // Final check on this fully processed and normalized response
+                                      let final_check_ss_segment = normalized_response.slice(s![ss_start_idx_local..ss_end_idx_local]);
+                                      if final_check_ss_segment.is_empty() { return None; } // Should not happen
+
+                                      final_check_ss_segment.mean()
+                                        .and_then(|final_normalized_ss_mean| {
+                                             if (final_normalized_ss_mean - 1.0).abs() <= FINAL_NORMALIZED_STEADY_STATE_TOLERANCE {
                                                  Some(normalized_response)
-                                             } else { None }
+                                             } else {
+                                                 // eprintln!("Debug: Axis {} final normalized ss_mean: {:.2} (target 1.0) failed tolerance {:.2}. Orig final_ss_mean_for_norm: {:.2}",
+                                                 //    axis_index_for_debug, // Pass axis_index if debugging
+                                                 //    final_normalized_ss_mean, FINAL_NORMALIZED_STEADY_STATE_TOLERANCE, final_ss_mean_for_norm);
+                                                 None
+                                             }
                                         })
-                                 } else { None }
+                                 } else {
+                                    // eprintln!("Debug: Axis {} final_ss_mean_for_norm near zero ({:.2e}), cannot normalize. Mask sum: {}",
+                                    //    axis_index_for_debug, // Pass axis_index if debugging
+                                    //    final_ss_mean_for_norm, mask.sum());
+                                    None
+                                 }
                             })
                     })
             };
 
             let mut series = Vec::new();
             if show_legend {
-                let final_low_response = process_response(&low_mask, valid_stacked_responses, response_length_samples, current_ss_start_sample, current_ss_end_sample, post_averaging_smoothing_window);
-                let final_high_response = process_response(&high_mask, valid_stacked_responses, response_length_samples, current_ss_start_sample, current_ss_end_sample, post_averaging_smoothing_window);
-                let final_combined_response = process_response(&combined_mask, valid_stacked_responses, response_length_samples, current_ss_start_sample, current_ss_end_sample, post_averaging_smoothing_window);
+                let final_low_response = process_response(&low_mask, valid_stacked_responses, response_length_samples, current_ss_start_idx, current_ss_end_idx, post_averaging_smoothing_window);
+                let final_high_response = process_response(&high_mask, valid_stacked_responses, response_length_samples, current_ss_start_idx, current_ss_end_idx, post_averaging_smoothing_window);
+                // The "Combined" response uses all QC'd windows.
+                let final_combined_response = process_response(&combined_mask, valid_stacked_responses, response_length_samples, current_ss_start_idx, current_ss_end_idx, post_averaging_smoothing_window);
+
                 if let Some(resp) = final_low_response {
                     series.push(PlotSeries {
                         data: response_time.iter().zip(resp.iter()).map(|(&t, &v)| (t, v)).collect(),
@@ -116,36 +167,51 @@ pub fn plot_step_response(
                     });
                 }
                 if let Some(resp) = final_combined_response {
-                    series.push(PlotSeries {
+                     series.push(PlotSeries {
                         data: response_time.iter().zip(resp.iter()).map(|(&t, &v)| (t, v)).collect(),
-                        label: "Combined".to_string(),
+                        label: "Combined".to_string(), // This is the average of all Y-corrected & QC'd responses
                         color: color_combined,
                         stroke_width: line_stroke_plot,
                     });
                 }
-            } else {
-                let final_combined_response = process_response(&combined_mask, valid_stacked_responses, response_length_samples, current_ss_start_sample, current_ss_end_sample, post_averaging_smoothing_window);
+            } else { // If not showing legend, only plot the "Combined" (average of all QC'd responses)
+                let final_combined_response = process_response(&combined_mask, valid_stacked_responses, response_length_samples, current_ss_start_idx, current_ss_end_idx, post_averaging_smoothing_window);
                 if let Some(resp) = final_combined_response {
                     series.push(PlotSeries {
                         data: response_time.iter().zip(resp.iter()).map(|(&t, &v)| (t, v)).collect(),
-                        label: format!("step-response"),
+                        label: format!("step-response \u{2265} {} deg/s", MOVEMENT_THRESHOLD_DEG_S), // Label reflects initial movement filter
                         color: color_combined,
                         stroke_width: line_stroke_plot,
                     });
                 }
             }
 
-            // Calculate y-range
+            if series.is_empty() {
+                // eprintln!("Debug: Axis {} has no series to plot after process_response.", axis_index);
+                continue; // No valid series generated for this axis
+            }
+
+            // Calculate y-range from the actual series data
             let mut resp_min = f64::INFINITY;
             let mut resp_max = f64::NEG_INFINITY;
-            for s in &series {
-                for &(_, v) in &s.data {
-                    resp_min = resp_min.min(v);
-                    resp_max = resp_max.max(v);
+            for s_data in &series {
+                for &(_, v) in &s_data.data {
+                    if v.is_finite() {
+                        resp_min = resp_min.min(v);
+                        resp_max = resp_max.max(v);
+                    }
                 }
             }
-            let (final_resp_min, final_resp_max) = calculate_range(resp_min, resp_max);
-            let x_range = 0f64..step_response_plot_duration_s * 1.05;
+
+            let (final_resp_min, final_resp_max) = if resp_min.is_finite() && resp_max.is_finite() {
+                calculate_range(resp_min, resp_max)
+            } else {
+                // Default range if no valid data, or handle as error
+                eprintln!("Warning: Axis {} has no finite data for Y-axis range calculation. Using default range.", axis_index);
+                (-0.2, 1.8) // A reasonable default for normalized step responses
+            };
+
+            let x_range = 0f64..step_response_plot_duration_s * 1.05; // Add a little padding to x-axis
             let y_range = final_resp_min..final_resp_max;
 
             plot_data_per_axis[axis_index] = Some((
@@ -169,8 +235,8 @@ pub fn plot_step_response(
         &output_file_step,
         root_name,
         plot_type_name,
-        move |axis_index| {
-            plot_data_per_axis[axis_index].take()
+        move |axis_idx_for_closure| { // Renamed to avoid conflict if axis_index is passed for debug
+            plot_data_per_axis[axis_idx_for_closure].take()
         },
     )
 }

--- a/src/plot_functions/plot_step_response.rs
+++ b/src/plot_functions/plot_step_response.rs
@@ -9,10 +9,7 @@ use crate::constants::{
     STEP_RESPONSE_PLOT_DURATION_S,
     POST_AVERAGING_SMOOTHING_WINDOW, STEADY_STATE_START_S, STEADY_STATE_END_S,
     COLOR_STEP_RESPONSE_LOW_SP, COLOR_STEP_RESPONSE_HIGH_SP, COLOR_STEP_RESPONSE_COMBINED,
-    LINE_WIDTH_PLOT, MOVEMENT_THRESHOLD_DEG_S,
-    // Assume you add this to constants.rs or use an existing suitable one:
-    // pub const FINAL_NORMALIZED_STEADY_STATE_TOLERANCE: f64 = 0.15;
-    // For now, I'll use a local const as an example if it's not in your constants.rs yet.
+    LINE_WIDTH_PLOT, MOVEMENT_THRESHOLD_DEG_S, FINAL_NORMALIZED_STEADY_STATE_TOLERANCE
 };
 use crate::data_analysis::calc_step_response; // For average_responses and moving_average_smooth_f64
 
@@ -35,10 +32,6 @@ pub fn plot_step_response(
     let color_combined: RGBColor = *COLOR_STEP_RESPONSE_COMBINED;
     let color_low_sp: RGBColor = *COLOR_STEP_RESPONSE_LOW_SP;
     let line_stroke_plot = LINE_WIDTH_PLOT;
-
-    // Example for the final tolerance, ideally this comes from constants.rs
-    const FINAL_NORMALIZED_STEADY_STATE_TOLERANCE: f64 = 0.15;
-
 
     let output_file_step = format!("{}_step_response_stacked_plot_{}s.png", root_name, step_response_plot_duration_s);
     let plot_type_name = "Step Response";


### PR DESCRIPTION
NOTE:  The binary now named **_Blackbox_CSV_Render_**, (not RUST_Blackbox_CSV_Render)
Binary available from github actions (Checks tab>Sumamry>scroll-down)

This PR fixes:
- step-response calculations for both below and above the threshold
- potential panic

This PR adds:
- finds peak response values and adds them into the legend.

PR tested personally and rigorously interrogated AI.
- interrogated AI locally
- also see #17
- closes #17

PR Testings requested:
- testing REQUIREMENT: commandline parameter `--dps` !!
- Please test against known fair-to-good tunes and compare/contrast to PIDtoolbox (PTB). The combined step-response should resemble PTB, but maybe even be more precise.
- please compare step-response graphs to what you know about your quad's physical behavior.
- please test against known under-tuned quads and compare to known physical behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved step response calculation with enhanced normalization and quality control for more robust and configurable analysis.
  - Added initial smoothing for gyro input and individual response Y-correction with new thresholds and parameters.
  - Enhanced steady-state validation and normalization in step response plots for increased reliability.

- **Bug Fixes**
  - Improved handling of steady-state window boundaries and empty data cases in plotting to prevent errors.

- **Style**
  - Minor formatting and comment clarifications applied throughout for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->