### PR TITLE
step-response: add latency labels

### DIFF
--- a/src/data_analysis/calc_step_response.rs
+++ b/src/data_analysis/calc_step_response.rs
@@ -319,6 +319,77 @@ pub fn calculate_step_response(
     Ok((response_time.mapv(|t| t as f64), valid_stacked_responses, valid_window_max_setpoints))
 }
 
+/// Calculates Delay Time (Td) - the time for the step response to reach 50% of its final value.
+/// Uses linear interpolation for a precise determination of the 50% threshold crossing.
+/// A fixed offset of -1ms is applied to the calculated time (in milliseconds) before converting to seconds.
+///
+/// # Arguments
+/// * `normalized_response` - A 1D array of the normalized step response (expected to go from ~0 to ~1).
+/// * `sample_rate` - The sample rate of the response data in Hz.
+///
+/// # Returns
+/// `Some(f64)` containing the delay time in seconds, or `None` if the response is empty,
+/// sample rate is invalid, or the 50% threshold is not crossed.
+pub fn calculate_delay_time(normalized_response: &Array1<f64>, sample_rate: f64) -> Option<f64> {
+    if normalized_response.is_empty() || sample_rate <= 0.0 {
+        return None;
+    }
+
+    let threshold = 0.5;
+    let mut interpolated_idx_0_based: Option<f64> = None;
+
+    // Check if the first point is at or above the threshold
+    if normalized_response[0] >= threshold {
+        interpolated_idx_0_based = Some(0.0);
+    } else {
+        for idx in 1..normalized_response.len() {
+            let y0 = normalized_response[idx - 1];
+            let y1 = normalized_response[idx];
+
+            if y0 < threshold && y1 >= threshold {
+                // Found a crossing
+                let x0 = (idx - 1) as f64; // 0-based index of point before crossing
+                let x1 = idx as f64;       // 0-based index of point at or after crossing
+
+                if (y1 - y0).abs() < 1e-9 { // Avoid division by zero if y1 is very close to y0
+                                            // This implies the segment is flat and at/crossing the threshold.
+                                            // Take the first point of this segment that is >= threshold.
+                    interpolated_idx_0_based = Some(x1);
+                } else {
+                    // Linear interpolation: x = x0 + (threshold - y0) * (x1 - x0) / (y1 - y0)
+                    let t = (threshold - y0) / (y1 - y0);
+                    interpolated_idx_0_based = Some(x0 + t * (x1 - x0));
+                }
+                break; // Found the first crossing
+            }
+        }
+    }
+
+    if let Some(idx_val) = interpolated_idx_0_based {
+        // Calculation of delay time in seconds:
+        // 1. Convert the 0-based (potentially fractional) interpolated index to a 1-based sample count.
+        //    This represents the number of samples (or fractional samples) into the response where the threshold is crossed.
+        let time_samples_1_based = idx_val + 1.0;
+        
+        // 2. Determine sample rate in samples per millisecond for time conversion.
+        let sample_rate_per_ms = sample_rate / 1000.0;
+        if sample_rate_per_ms <= 1e-9 { // Avoid division by zero or issues with very low sample rates
+            return None;
+        }
+        
+        // 3. Calculate the time to threshold in milliseconds.
+        let time_ms = time_samples_1_based / sample_rate_per_ms;
+        
+        // 4. Apply a 1ms subtraction offset to the time in milliseconds.
+        let delay_ms = time_ms - 1.0;
+        
+        // 5. Convert to seconds and ensure the result is non-negative.
+        Some((delay_ms / 1000.0).max(0.0))
+    } else {
+        None // Threshold not crossed
+    }
+}
+
 /// Finds the peak (maximum) value in a 1D response data array.
 /// Returns None if the array is empty or contains no finite values.
 pub fn find_peak_value(response_data: &Array1<f64>) -> Option<f64> {

--- a/src/data_analysis/calc_step_response.rs
+++ b/src/data_analysis/calc_step_response.rs
@@ -335,6 +335,13 @@ pub fn calculate_delay_time(normalized_response: &Array1<f64>, sample_rate: f64)
         return None;
     }
 
+    // Validate that this looks like a normalized step response
+    let final_value = normalized_response[normalized_response.len() - 1];
+    if final_value < 0.1 || final_value > 2.0 {
+        // Response doesn't appear to be a normalized step response
+        return None;
+    }
+
     let threshold = 0.5;
     let mut interpolated_idx_0_based: Option<f64> = None;
 

--- a/src/plot_functions/plot_step_response.rs
+++ b/src/plot_functions/plot_step_response.rs
@@ -74,7 +74,7 @@ pub fn plot_step_response(
                 ss_start_idx_local: usize,
                 ss_end_idx_local: usize,
                 smoothing_window: usize,
-            | -> Option<Array1<f64>> {
+            | -> Option<Array1<f64>> { // Return type simplified to just the response array
                 if !mask.iter().any(|&w| w > 0.0) { return None; } // No windows selected by mask
 
                 // avg_resp is now an average of *individually Y-corrected* (mostly normalized towards 1) responses
@@ -100,7 +100,6 @@ pub fn plot_step_response(
                          // smoothed, and shifted response. Its mean is used for a final normalization refinement.
                          let steady_state_segment = shifted_response.slice(s![ss_start_idx_local..ss_end_idx_local]);
                          if steady_state_segment.is_empty() { // Guard against empty slice
-                            // eprintln!("Debug: Axis {} steady_state_segment for final norm is empty. Start: {}, End: {}, Len: {}", axis_index, ss_start_idx_local, ss_end_idx_local, shifted_response.len());
                             return None;
                          }
 
@@ -120,16 +119,10 @@ pub fn plot_step_response(
                                              if (final_normalized_ss_mean - 1.0).abs() <= FINAL_NORMALIZED_STEADY_STATE_TOLERANCE {
                                                  Some(normalized_response)
                                              } else {
-                                                 // eprintln!("Debug: Axis {} final normalized ss_mean: {:.2} (target 1.0) failed tolerance {:.2}. Orig final_ss_mean_for_norm: {:.2}",
-                                                 //    axis_index_for_debug, // Pass axis_index if debugging
-                                                 //    final_normalized_ss_mean, FINAL_NORMALIZED_STEADY_STATE_TOLERANCE, final_ss_mean_for_norm);
                                                  None
                                              }
                                         })
                                  } else {
-                                    // eprintln!("Debug: Axis {} final_ss_mean_for_norm near zero ({:.2e}), cannot normalize. Mask sum: {}",
-                                    //    axis_index_for_debug, // Pass axis_index if debugging
-                                    //    final_ss_mean_for_norm, mask.sum());
                                     None
                                  }
                             })
@@ -145,30 +138,36 @@ pub fn plot_step_response(
 
                 if let Some(resp) = final_low_response {
                     let peak_val_opt = calc_step_response::find_peak_value(&resp);
+                    let latency_opt = calc_step_response::calculate_delay_time(&resp, sr);
                     let peak_str = peak_val_opt.map_or_else(|| "N/A".to_string(), |p| format!("{:.2}", p));
+                    let latency_str = latency_opt.map_or_else(|| "N/A".to_string(), |l_s| format!("{:.0} ms", l_s * 1000.0));
                     series.push(PlotSeries {
                         data: response_time.iter().zip(resp.iter()).map(|(&t, &v)| (t, v)).collect(),
-                        label: format!("< {} deg/s (Peak: {})", setpoint_threshold, peak_str),
+                        label: format!("< {} deg/s (Peak: {}, Td: {})", setpoint_threshold, peak_str, latency_str),
                         color: color_low_sp,
                         stroke_width: line_stroke_plot,
                     });
                 }
                 if let Some(resp) = final_high_response {
                     let peak_val_opt = calc_step_response::find_peak_value(&resp);
+                    let latency_opt = calc_step_response::calculate_delay_time(&resp, sr);
                     let peak_str = peak_val_opt.map_or_else(|| "N/A".to_string(), |p| format!("{:.2}", p));
+                    let latency_str = latency_opt.map_or_else(|| "N/A".to_string(), |l_s| format!("{:.0} ms", l_s * 1000.0));
                     series.push(PlotSeries {
                         data: response_time.iter().zip(resp.iter()).map(|(&t, &v)| (t, v)).collect(),
-                        label: format!("\u{2265} {} deg/s (Peak: {})", setpoint_threshold, peak_str),
+                        label: format!("\u{2265} {} deg/s (Peak: {}, Td: {})", setpoint_threshold, peak_str, latency_str),
                         color: color_high_sp,
                         stroke_width: line_stroke_plot,
                     });
                 }
                 if let Some(resp) = final_combined_response {
                     let peak_val_opt = calc_step_response::find_peak_value(&resp);
+                    let latency_opt = calc_step_response::calculate_delay_time(&resp, sr);
                     let peak_str = peak_val_opt.map_or_else(|| "N/A".to_string(), |p| format!("{:.2}", p));
+                    let latency_str = latency_opt.map_or_else(|| "N/A".to_string(), |l_s| format!("{:.0} ms", l_s * 1000.0));
                      series.push(PlotSeries {
                         data: response_time.iter().zip(resp.iter()).map(|(&t, &v)| (t, v)).collect(),
-                        label: format!("Combined (Peak: {})", peak_str), // This is the average of all Y-corrected & QC'd responses
+                        label: format!("Combined (Peak: {}, Td: {})", peak_str, latency_str), // This is the average of all Y-corrected & QC'd responses
                         color: color_combined,
                         stroke_width: line_stroke_plot,
                     });
@@ -176,9 +175,11 @@ pub fn plot_step_response(
             } else { // If not showing legend, only plot the "Combined" (average of all QC'd responses)
                 let final_combined_response = process_response(&combined_mask, valid_stacked_responses, response_length_samples, current_ss_start_idx, current_ss_end_idx, post_averaging_smoothing_window);
                 if let Some(resp) = final_combined_response {
+                    let latency_opt = calc_step_response::calculate_delay_time(&resp, sr);
+                    let latency_str = latency_opt.map_or_else(|| "N/A".to_string(), |l_s| format!("{:.0} ms", l_s * 1000.0));
                     series.push(PlotSeries {
                         data: response_time.iter().zip(resp.iter()).map(|(&t, &v)| (t, v)).collect(),
-                        label: format!("step-response \u{2265} {} deg/s", MOVEMENT_THRESHOLD_DEG_S), // Label reflects initial movement filter
+                        label: format!("step-response \u{2265} {} deg/s (Td: {})", MOVEMENT_THRESHOLD_DEG_S, latency_str), // Label reflects initial movement filter
                         color: color_combined,
                         stroke_width: line_stroke_plot,
                     });


### PR DESCRIPTION
The `calculate_delay_time` function determines latency (Delay Time, Td) as follows:

1.  It finds when the normalized step response first crosses 50% of its final value.
2.  Linear interpolation is used between the samples bracketing this 50% threshold to find a precise (potentially fractional) sample index for the crossing.
3.  This interpolated sample index is converted to time in milliseconds using the provided sample rate.
4.  A fixed -1ms offset is subtracted from this calculated time.
5.  The result is then converted to seconds and ensured to be non-negative.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Step response plots now display latency (delay time) information in series labels, shown in milliseconds alongside peak values.
  - Added calculation of delay time for normalized step responses, enhancing analysis precision.

- **Style**
  - Improved plot legend and labeling for greater clarity.

- **Chores**
  - Removed obsolete debug print statements for cleaner output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->