### PR TITLE
allow BBE exported CSV files

### DIFF
--- a/src/data_input/log_parser.rs
+++ b/src/data_input/log_parser.rs
@@ -49,8 +49,16 @@ pub fn parse_log_file(
         let header_record = reader.headers()?.clone();
         println!("Headers found in CSV: {:?}", header_record);
 
-        header_indices = target_headers.iter().map(|&target_header| {
-            header_record.iter().position(|h| h.trim() == target_header)
+        header_indices = target_headers.iter().enumerate().map(|(i, &target_header)| {
+            if i == 0 {
+                // Special case for time header: check for both "time (us)" and "time"
+                header_record.iter().position(|h| {
+                    let trimmed = h.trim();
+                    trimmed == "time (us)" || trimmed == "time"
+                })
+            } else {
+                header_record.iter().position(|h| h.trim() == target_header)
+            }
         }).collect();
 
         println!("Header mapping status:");

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,6 +87,7 @@ fn process_file(input_file_str: &str, setpoint_threshold: f64, show_legend: bool
         gyro_header_found,
         _gyro_unfilt_header_found,
         _debug_header_found,
+        _metadata,
     ) = match parse_log_file(&input_path) {
         Ok(data) => data,
         Err(e) => {


### PR DESCRIPTION
- **allow "time" trimmed header**
- **allow BBE CSV headers skipping to actual flightlog data**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Log file parsing now extracts and returns metadata key-value pairs found before the CSV headers.
  - Improved header detection supports both "time (us)" and "time" as valid time column headers.

- **Bug Fixes**
  - Enhanced robustness in distinguishing between metadata, headers, and data lines during log file parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->