### PR TITLE
feat: implement header metadata reading for both CSV types

### DIFF
--- a/src/data_input/log_parser.rs
+++ b/src/data_input/log_parser.rs
@@ -2,11 +2,51 @@
 
 use csv::ReaderBuilder;
 use std::error::Error;
-use std::path::Path;
 use std::fs::File;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::Path;
 
 use crate::data_input::log_data::LogRowData;
+
+/// Reads a separate .headers.csv file and extracts header metadata key-value pairs
+fn read_headers_csv(headers_file_path: &Path) -> Result<Vec<(String, String)>, Box<dyn Error>> {
+    let mut header_metadata = Vec::new();
+    let file = File::open(headers_file_path)?;
+    let mut reader = ReaderBuilder::new()
+        .has_headers(false) // Headers files typically don't have a header row
+        .trim(csv::Trim::All)
+        .from_reader(BufReader::new(file));
+
+    for result in reader.records() {
+        match result {
+            Ok(record) => {
+                if record.len() >= 2 {
+                    let key = record
+                        .get(0)
+                        .unwrap_or("")
+                        .trim()
+                        .trim_matches('"')
+                        .to_string();
+                    let value = record
+                        .get(1)
+                        .unwrap_or("")
+                        .trim()
+                        .trim_matches('"')
+                        .to_string();
+                    if !key.is_empty() {
+                        header_metadata.push((key, value));
+                    }
+                }
+            }
+            Err(e) => {
+                println!("Warning: Error parsing headers CSV line: {}", e);
+                // Continue processing other lines
+            }
+        }
+    }
+
+    Ok(header_metadata)
+}
 
 /// Parses the CSV log file, extracts data, determines header presence, and calculates sample rate.
 ///
@@ -18,56 +58,123 @@ use crate::data_input::log_data::LogRowData;
 /// 5. `[bool; 3]`: Flags indicating if gyroADC[0-2] headers were found.
 /// 6. `[bool; 3]`: Flags indicating if gyroUnfilt[0-2] headers were found.
 /// 7. `[bool; 4]`: Flags indicating if debug[0-3] headers were found.
-/// 8. `Vec<(String, String)>`: Metadata key-value pairs found before CSV headers.
+/// 8. `Vec<(String, String)>`: Header metadata key-value pairs found before CSV headers.
 pub fn parse_log_file(
     input_file_path: &Path,
-) -> Result<(Vec<LogRowData>, Option<f64>, [bool; 3], [bool; 4], [bool; 3], [bool; 3], [bool; 4], Vec<(String, String)>), Box<dyn Error>> {
+    debug_mode: bool,
+) -> Result<
+    (
+        Vec<LogRowData>,
+        Option<f64>,
+        [bool; 3],
+        [bool; 4],
+        [bool; 3],
+        [bool; 3],
+        [bool; 4],
+        Vec<(String, String)>,
+    ),
+    Box<dyn Error>,
+> {
     // --- Header Definition and Index Mapping ---
     let target_headers = [
-        "time (us)",            // 0
-        "axisP[0]", "axisP[1]", "axisP[2]", // 1, 2, 3
-        "axisI[0]", "axisI[1]", "axisI[2]", // 4, 5, 6
-        "axisD[0]", "axisD[1]", "axisD[2]", // 7, 8, 9
-        "axisF[0]", "axisF[1]", "axisF[2]", // 10, 11, 12
-        "setpoint[0]", "setpoint[1]", "setpoint[2]", "setpoint[3]", // 13, 14, 15, 16 (setpoint[3] is throttle)
-        "gyroADC[0]", "gyroADC[1]", "gyroADC[2]", // 17, 18, 19
-        "gyroUnfilt[0]", "gyroUnfilt[1]", "gyroUnfilt[2]", // 20, 21, 22
-        "debug[0]", "debug[1]", "debug[2]", "debug[3]", // 23, 24, 25, 26
+        "time (us)", // 0
+        "axisP[0]",
+        "axisP[1]",
+        "axisP[2]", // 1, 2, 3
+        "axisI[0]",
+        "axisI[1]",
+        "axisI[2]", // 4, 5, 6
+        "axisD[0]",
+        "axisD[1]",
+        "axisD[2]", // 7, 8, 9
+        "axisF[0]",
+        "axisF[1]",
+        "axisF[2]", // 10, 11, 12
+        "setpoint[0]",
+        "setpoint[1]",
+        "setpoint[2]",
+        "setpoint[3]", // 13, 14, 15, 16 (setpoint[3] is throttle)
+        "gyroADC[0]",
+        "gyroADC[1]",
+        "gyroADC[2]", // 17, 18, 19
+        "gyroUnfilt[0]",
+        "gyroUnfilt[1]",
+        "gyroUnfilt[2]", // 20, 21, 22
+        "debug[0]",
+        "debug[1]",
+        "debug[2]",
+        "debug[3]", // 23, 24, 25, 26
     ];
 
-    // --- Metadata Extraction and CSV Position Tracking ---
-    let mut metadata: Vec<(String, String)> = Vec::new();
+    // --- Header Metadata Extraction and CSV Position Tracking ---
+    let mut header_metadata: Vec<(String, String)> = Vec::new();
+
+    // First, check for separate .headers.csv file (Type 1)
+    let headers_file_path = {
+        let file_stem = input_file_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("");
+        input_file_path.with_file_name(format!("{}.headers.csv", file_stem))
+    };
+
+    if headers_file_path.exists() {
+        if debug_mode {
+            println!("Found separate headers file: {:?}", headers_file_path);
+        }
+        match read_headers_csv(&headers_file_path) {
+            Ok(mut headers_metadata) => {
+                if debug_mode {
+                    println!(
+                        "Successfully read {} entries from headers file",
+                        headers_metadata.len()
+                    );
+                }
+                header_metadata.append(&mut headers_metadata);
+            }
+            Err(e) => {
+                println!("Warning: Failed to read headers file: {}", e);
+            }
+        }
+    }
+
     let csv_start_position: u64;
-    
-    // Single-pass file reading: extract metadata and find CSV start position
+
+    // Next, extract embedded header metadata from the CSV file itself (Type 2)
+    // Single-pass file reading: extract header metadata and find CSV start position
+    let embedded_start_count = header_metadata.len(); // Track how many we had from headers file
     {
         let mut file = File::open(input_file_path)?;
         let mut reader = BufReader::new(&mut file);
         let mut line_buffer = String::new();
         let mut current_position = 0u64;
-        
+
         loop {
             line_buffer.clear();
             let bytes_read = reader.read_line(&mut line_buffer)?;
             if bytes_read == 0 {
                 return Err("Reached end of file without finding CSV headers".into());
             }
-            
+
             let trimmed_line = line_buffer.trim();
-            
+
             // Skip empty lines
             if trimmed_line.is_empty() {
                 current_position += bytes_read as u64;
                 continue;
             }
-            
+
             // Check if this line contains the CSV headers
-            if trimmed_line.contains("time") && (trimmed_line.contains("axisP") || trimmed_line.contains("gyroADC")) {
+            if trimmed_line.contains("time")
+                && (trimmed_line.contains("axisP") || trimmed_line.contains("gyroADC"))
+            {
                 csv_start_position = current_position;
-                println!("Found CSV headers at file position {}", csv_start_position);
+                if debug_mode {
+                    println!("Found CSV headers at file position {}", csv_start_position);
+                }
                 break;
             }
-            
+
             // Parse metadata line directly without CSV reader (more efficient)
             if trimmed_line.contains(',') {
                 let parts: Vec<&str> = trimmed_line.splitn(2, ',').collect();
@@ -75,23 +182,33 @@ pub fn parse_log_file(
                     let key = parts[0].trim().trim_matches('"').to_string();
                     let value = parts[1].trim().trim_matches('"').to_string();
                     if !key.is_empty() {
-                        metadata.push((key, value));
+                        header_metadata.push((key, value));
                     }
                 }
             }
-            
+
             current_position += bytes_read as u64;
         }
     }
-    
-    println!("Extracted {} metadata entries", metadata.len());
-    if !metadata.is_empty() {
-        println!("Sample metadata:");
-        for (i, (key, value)) in metadata.iter().take(5).enumerate() {
+
+    if embedded_start_count > 0 {
+        println!(
+            "Extracted {} total header metadata (separate header file)",
+            header_metadata.len()
+        );
+    } else {
+        println!(
+            "Extracted {} total header metadata (embedded)",
+            header_metadata.len()
+        );
+    }
+    if debug_mode && !header_metadata.is_empty() {
+        println!("Sample header metadata:");
+        for (i, (key, value)) in header_metadata.iter().take(5).enumerate() {
             println!("  {}: '{}' = '{}'", i + 1, key, value);
         }
-        if metadata.len() > 5 {
-            println!("  ... and {} more", metadata.len() - 5);
+        if header_metadata.len() > 5 {
+            println!("  ... and {} more", header_metadata.len() - 5);
         }
     }
 
@@ -107,30 +224,42 @@ pub fn parse_log_file(
     {
         let mut file = File::open(input_file_path)?;
         file.seek(SeekFrom::Start(csv_start_position))?;
-        let mut reader = ReaderBuilder::new().has_headers(true).trim(csv::Trim::All).from_reader(BufReader::new(file));
+        let mut reader = ReaderBuilder::new()
+            .has_headers(true)
+            .trim(csv::Trim::All)
+            .from_reader(BufReader::new(file));
         let header_record = reader.headers()?.clone();
-        println!("Headers found in CSV: {:?}", header_record);
+        println!("Flight data keys found in CSV: {:?}", header_record);
 
-        header_indices = target_headers.iter().enumerate().map(|(i, &target_header)| {
-            if i == 0 {
-                // Special case for time header: check for both "time (us)" and "time"
-                header_record.iter().position(|h| {
-                    let trimmed = h.trim();
-                    trimmed == "time (us)" || trimmed == "time"
-                })
-            } else {
-                header_record.iter().position(|h| h.trim() == target_header)
-            }
-        }).collect();
+        header_indices = target_headers
+            .iter()
+            .enumerate()
+            .map(|(i, &target_header)| {
+                if i == 0 {
+                    // Special case for time header: check for both "time (us)" and "time"
+                    header_record.iter().position(|h| {
+                        let trimmed = h.trim();
+                        trimmed == "time (us)" || trimmed == "time"
+                    })
+                } else {
+                    header_record.iter().position(|h| h.trim() == target_header)
+                }
+            })
+            .collect();
 
-        println!("Header mapping status:");
+        println!("Flight data key mapping:");
         let mut essential_pid_headers_found = true;
 
         // Check essential PID headers (Time, P, I, D[0], D[1]).
-        for i in 0..=8 { // Indices 0 through 8
+        for i in 0..=8 {
+            // Indices 0 through 8
             let name = target_headers[i];
             let found = header_indices[i].is_some();
-            println!("  '{}': {}", name, if found { "Found" } else { "Not Found" });
+            println!(
+                "  '{}': {}",
+                name,
+                if found { "Found" } else { "Not Found" }
+            );
             if !found {
                 essential_pid_headers_found = false;
             }
@@ -138,46 +267,108 @@ pub fn parse_log_file(
 
         // Check optional 'axisD[2]' header (Index 9).
         let axis_d2_found_in_csv = header_indices[9].is_some();
-        println!("  '{}': {} (Optional, defaults to 0.0 if not found)", target_headers[9], if axis_d2_found_in_csv { "Found" } else { "Not Found" });
+        println!(
+            "  '{}': {} (Optional, defaults to 0.0 if not found)",
+            target_headers[9],
+            if axis_d2_found_in_csv {
+                "Found"
+            } else {
+                "Not Found"
+            }
+        );
 
         // Check f_term headers (Indices 10-12).
         for axis in 0..3 {
             f_term_header_found[axis] = header_indices[10 + axis].is_some();
-            println!("  '{}': {} (Optional, defaults to 0.0 if not found)", target_headers[10 + axis], if f_term_header_found[axis] { "Found" } else { "Not Found" });
+            println!(
+                "  '{}': {} (Optional, defaults to 0.0 if not found)",
+                target_headers[10 + axis],
+                if f_term_header_found[axis] {
+                    "Found"
+                } else {
+                    "Not Found"
+                }
+            );
         }
 
         // Check setpoint headers (Indices 13-16).
-        for axis in 0..4 { // Check setpoint[0] to setpoint[3]
+        for axis in 0..4 {
+            // Check setpoint[0] to setpoint[3]
             setpoint_header_found[axis] = header_indices[13 + axis].is_some();
             let purpose = if axis < 3 {
-                format!("Essential for Setpoint plots and Step Response Axis {}", axis)
+                format!(
+                    "Essential for Setpoint plots and Step Response Axis {}",
+                    axis
+                )
             } else {
                 "Throttle (setpoint[3])".to_string()
             };
-            println!("  '{}': {} ({})", target_headers[13 + axis], if setpoint_header_found[axis] { "Found" } else { "Not Found" }, purpose);
+            println!(
+                "  '{}': {} ({})",
+                target_headers[13 + axis],
+                if setpoint_header_found[axis] {
+                    "Found"
+                } else {
+                    "Not Found"
+                },
+                purpose
+            );
         }
 
         // Check gyro (filtered) headers (Indices 17-19).
         for axis in 0..3 {
             gyro_header_found[axis] = header_indices[17 + axis].is_some();
-            println!("  '{}': {} (Essential for Step Response, Gyro plots, and PID Error Axis {})", target_headers[17 + axis], if gyro_header_found[axis] { "Found" } else { "Not Found" }, axis);
+            println!(
+                "  '{}': {} (Essential for Step Response, Gyro plots, and PID Error Axis {})",
+                target_headers[17 + axis],
+                if gyro_header_found[axis] {
+                    "Found"
+                } else {
+                    "Not Found"
+                },
+                axis
+            );
         }
 
         // Check gyroUnfilt headers (Indices 20-22).
         for axis in 0..3 {
             gyro_unfilt_header_found[axis] = header_indices[20 + axis].is_some();
-            println!("  '{}': {} (Fallback for Gyro vs Unfilt Axis {})", target_headers[20 + axis], if gyro_unfilt_header_found[axis] { "Found" } else { "Not Found" }, axis);
+            println!(
+                "  '{}': {} (Fallback for Gyro vs Unfilt Axis {})",
+                target_headers[20 + axis],
+                if gyro_unfilt_header_found[axis] {
+                    "Found"
+                } else {
+                    "Not Found"
+                },
+                axis
+            );
         }
 
         // Check debug headers (Indices 23-26).
         for idx_offset in 0..4 {
             debug_header_found[idx_offset] = header_indices[23 + idx_offset].is_some();
-            println!("  '{}': {} (Fallback for gyroUnfilt[0-2])", target_headers[23 + idx_offset], if debug_header_found[idx_offset] { "Found" } else { "Not Found" });
+            println!(
+                "  '{}': {} (Fallback for gyroUnfilt[0-2])",
+                target_headers[23 + idx_offset],
+                if debug_header_found[idx_offset] {
+                    "Found"
+                } else {
+                    "Not Found"
+                }
+            );
         }
 
         if !essential_pid_headers_found {
-            let missing_essentials: Vec<String> = (0..=8).filter(|&i| header_indices[i].is_none()).map(|i| format!("'{}'", target_headers[i])).collect();
-            return Err(format!("Error: Missing essential headers for PIDsum calculation: {}. Aborting.", missing_essentials.join(", ")).into());
+            let missing_essentials: Vec<String> = (0..=8)
+                .filter(|&i| header_indices[i].is_none())
+                .map(|i| format!("'{}'", target_headers[i]))
+                .collect();
+            return Err(format!(
+                "Error: Missing essential headers for PIDsum calculation: {}. Aborting.",
+                missing_essentials.join(", ")
+            )
+            .into());
         }
     }
 
@@ -187,7 +378,10 @@ pub fn parse_log_file(
     {
         let mut file = File::open(input_file_path)?;
         file.seek(SeekFrom::Start(csv_start_position))?;
-        let mut reader = ReaderBuilder::new().has_headers(true).trim(csv::Trim::All).from_reader(BufReader::new(file));
+        let mut reader = ReaderBuilder::new()
+            .has_headers(true)
+            .trim(csv::Trim::All)
+            .from_reader(BufReader::new(file));
 
         for (row_index, result) in reader.records().enumerate() {
             match result {
@@ -195,7 +389,8 @@ pub fn parse_log_file(
                     let mut current_row_data = LogRowData::default();
 
                     let parse_f64_by_target_idx = |target_idx: usize| -> Option<f64> {
-                        header_indices.get(target_idx)
+                        header_indices
+                            .get(target_idx)
                             .and_then(|opt_csv_idx| opt_csv_idx.as_ref())
                             .and_then(|&csv_idx| record.get(csv_idx))
                             .and_then(|val_str| val_str.parse::<f64>().ok())
@@ -206,7 +401,10 @@ pub fn parse_log_file(
                     if let Some(t_us) = time_us {
                         current_row_data.time_sec = Some(t_us / 1_000_000.0);
                     } else {
-                        eprintln!("Warning: Skipping row {} due to missing or invalid 'time (us)'", row_index + 1);
+                        eprintln!(
+                            "Warning: Skipping row {} due to missing or invalid 'time (us)'",
+                            row_index + 1
+                        );
                         continue;
                     }
 
@@ -230,12 +428,14 @@ pub fn parse_log_file(
                         } else {
                             current_row_data.f_term[axis] = Some(0.0);
                         }
-                        current_row_data.gyro[axis] = parse_f64_by_target_idx(17 + axis); // Indices 17,18,19
+                        current_row_data.gyro[axis] = parse_f64_by_target_idx(17 + axis);
+                        // Indices 17,18,19
                     }
 
                     // Parse Setpoint (for axes 0-3)
                     for axis in 0..4 {
-                        current_row_data.setpoint[axis] = parse_f64_by_target_idx(13 + axis); // Indices 13,14,15,16
+                        current_row_data.setpoint[axis] = parse_f64_by_target_idx(13 + axis);
+                        // Indices 13,14,15,16
                     }
 
                     // Parse gyroUnfilt and debug
@@ -243,13 +443,15 @@ pub fn parse_log_file(
                     let mut parsed_debug = [None; 4];
                     for axis in 0..3 {
                         if gyro_unfilt_header_found[axis] {
-                            parsed_gyro_unfilt[axis] = parse_f64_by_target_idx(20 + axis); // Indices 20,21,22
+                            parsed_gyro_unfilt[axis] = parse_f64_by_target_idx(20 + axis);
+                            // Indices 20,21,22
                         }
                     }
 
                     for idx_offset in 0..4 {
                         if debug_header_found[idx_offset] {
-                            parsed_debug[idx_offset] = parse_f64_by_target_idx(23 + idx_offset); // Indices 23,24,25,26
+                            parsed_debug[idx_offset] = parse_f64_by_target_idx(23 + idx_offset);
+                            // Indices 23,24,25,26
                         }
                         current_row_data.debug[idx_offset] = parsed_debug[idx_offset];
                     }
@@ -261,14 +463,18 @@ pub fn parse_log_file(
                             None => match parsed_debug[axis] {
                                 Some(val) => Some(val),
                                 None => None,
-                            }
+                            },
                         };
                     }
 
                     all_log_data.push(current_row_data);
                 }
                 Err(e) => {
-                    eprintln!("Warning: Skipping row {} due to CSV read error: {}", row_index + 1, e);
+                    eprintln!(
+                        "Warning: Skipping row {} due to CSV read error: {}",
+                        row_index + 1,
+                        e
+                    );
                 }
             }
         }
@@ -301,10 +507,19 @@ pub fn parse_log_file(
         }
     }
     if sample_rate.is_none() {
-         println!("Warning: Could not determine sample rate (need >= 2 data points with distinct timestamps). Step response calculation might be affected.");
+        println!("Warning: Could not determine sample rate (need >= 2 data points with distinct timestamps). Step response calculation might be affected.");
     }
 
-    Ok((all_log_data, sample_rate, f_term_header_found, setpoint_header_found, gyro_header_found, gyro_unfilt_header_found, debug_header_found, metadata))
+    Ok((
+        all_log_data,
+        sample_rate,
+        f_term_header_found,
+        setpoint_header_found,
+        gyro_header_found,
+        gyro_unfilt_header_found,
+        debug_header_found,
+        header_metadata,
+    ))
 }
 
 // src/data_input/log_parser.rs

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,23 +6,25 @@ mod data_input;
 mod plot_framework;
 mod plot_functions;
 
-use std::error::Error;
+use std::collections::HashSet;
 use std::env;
-use std::path::{Path, PathBuf}; // Added PathBuf
-use std::collections::HashSet;  // Added HashSet
+use std::error::Error;
+use std::path::{Path, PathBuf}; // Added PathBuf // Added HashSet
 
 use ndarray::{Array1, Array2};
 
-use crate::constants::{DEFAULT_SETPOINT_THRESHOLD, EXCLUDE_START_S, EXCLUDE_END_S, FRAME_LENGTH_S};
+use crate::constants::{
+    DEFAULT_SETPOINT_THRESHOLD, EXCLUDE_END_S, EXCLUDE_START_S, FRAME_LENGTH_S,
+};
 
 // Specific plot function imports
-use crate::plot_functions::plot_pidsum_error_setpoint::plot_pidsum_error_setpoint;
-use crate::plot_functions::plot_setpoint_vs_gyro::plot_setpoint_vs_gyro;
-use crate::plot_functions::plot_gyro_vs_unfilt::plot_gyro_vs_unfilt;
-use crate::plot_functions::plot_step_response::plot_step_response;
 use crate::plot_functions::plot_gyro_spectrums::plot_gyro_spectrums;
+use crate::plot_functions::plot_gyro_vs_unfilt::plot_gyro_vs_unfilt;
+use crate::plot_functions::plot_pidsum_error_setpoint::plot_pidsum_error_setpoint;
 use crate::plot_functions::plot_psd::plot_psd;
 use crate::plot_functions::plot_psd_db_heatmap::plot_psd_db_heatmap;
+use crate::plot_functions::plot_setpoint_vs_gyro::plot_setpoint_vs_gyro;
+use crate::plot_functions::plot_step_response::plot_step_response;
 use crate::plot_functions::plot_throttle_freq_heatmap::plot_throttle_freq_heatmap;
 
 // Data input import
@@ -33,26 +35,42 @@ use crate::data_analysis::calc_step_response;
 
 fn print_usage_and_exit(program_name: &str) {
     eprintln!("
-Usage: {} <input_file1.csv> [<input_file2.csv> ...] [--dps <value>] [--output-dir <directory>]", program_name);
+Usage: {} <input_file1.csv> [<input_file2.csv> ...] [--dps <value>] [--output-dir <directory>] [--debug]", program_name);
     eprintln!("  <input_fileX.csv>: Path to one or more input CSV log files (required).");
     eprintln!("  --dps <value>: Optional. Enables detailed step response plots with the specified");
     eprintln!("                 deg/s threshold value. Must be a positive number.");
     eprintln!("                 If --dps is omitted, a general step-response is shown.");
-    eprintln!("  --output-dir <directory>: Optional. Specifies the output directory for generated plots.");
+    eprintln!(
+        "  --output-dir <directory>: Optional. Specifies the output directory for generated plots."
+    );
     eprintln!("                         If omitted, plots are saved in the source folder (input file's directory).");
+    eprintln!("  --debug: Optional. Shows detailed metadata information during processing.");
     eprintln!("  --help: Show this help message and exit.");
     eprintln!("  --version: Show version information and exit.");
-    eprintln!("
-Arguments can be in any order. Wildcards (e.g., *.csv) are supported by the shell.");
+    eprintln!(
+        "
+Arguments can be in any order. Wildcards (e.g., *.csv) are supported by the shell."
+    );
     std::process::exit(1);
 }
 
 fn print_version_and_exit() {
-    println!("{} version {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    println!(
+        "{} version {}",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION")
+    );
     std::process::exit(0);
 }
 
-fn process_file(input_file_str: &str, setpoint_threshold: f64, show_legend: bool, use_dir_prefix: bool, output_dir: Option<&str>) -> Result<(), Box<dyn Error>> {
+fn process_file(
+    input_file_str: &str,
+    setpoint_threshold: f64,
+    show_legend: bool,
+    use_dir_prefix: bool,
+    output_dir: Option<&str>,
+    debug_mode: bool,
+) -> Result<(), Box<dyn Error>> {
     // --- Setup paths and names ---
     let input_path = Path::new(input_file_str);
     if !input_path.exists() {
@@ -61,7 +79,10 @@ fn process_file(input_file_str: &str, setpoint_threshold: f64, show_legend: bool
     }
     println!("\n--- Processing file: {} ---", input_file_str);
 
-    let file_stem_cow = input_path.file_stem().unwrap_or_else(|| std::ffi::OsStr::new("unknown_filestem")).to_string_lossy();
+    let file_stem_cow = input_path
+        .file_stem()
+        .unwrap_or_else(|| std::ffi::OsStr::new("unknown_filestem"))
+        .to_string_lossy();
     let root_name_string: String;
 
     if use_dir_prefix {
@@ -71,9 +92,16 @@ fn process_file(input_file_str: &str, setpoint_threshold: f64, show_legend: bool
                 let dir_name_part = dir_os_str.to_string_lossy();
                 // Add prefix only if parent dir name is meaningful (not empty, not current dir indicator like ".")
                 if !dir_name_part.is_empty() && dir_name_part != "." {
-                    let sanitized_dir = dir_name_part.chars().map(|c|
-                        if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' }
-                    ).collect::<String>();
+                    let sanitized_dir = dir_name_part
+                        .chars()
+                        .map(|c| {
+                            if c.is_alphanumeric() || c == '-' || c == '_' {
+                                c
+                            } else {
+                                '_'
+                            }
+                        })
+                        .collect::<String>();
                     dir_prefix_to_add = format!("{}_", sanitized_dir);
                 }
             }
@@ -92,8 +120,8 @@ fn process_file(input_file_str: &str, setpoint_threshold: f64, show_legend: bool
         gyro_header_found,
         _gyro_unfilt_header_found,
         _debug_header_found,
-        _metadata,
-    ) = match parse_log_file(&input_path) {
+        _header_metadata,
+    ) = match parse_log_file(&input_path, debug_mode) {
         Ok(data) => data,
         Err(e) => {
             eprintln!("Error parsing log file {}: {}", input_file_str, e);
@@ -102,14 +130,20 @@ fn process_file(input_file_str: &str, setpoint_threshold: f64, show_legend: bool
     };
 
     if all_log_data.is_empty() {
-        println!("No valid data rows read from {}, cannot generate plots.", input_file_str);
+        println!(
+            "No valid data rows read from {}, cannot generate plots.",
+            input_file_str
+        );
         return Ok(());
     }
 
     let mut has_nonzero_f_term_data = [false; 3];
     for axis in 0..3 {
         if f_term_header_found[axis] {
-            if all_log_data.iter().any(|row| row.f_term[axis].map_or(false, |val| val.abs() > 1e-9)) {
+            if all_log_data
+                .iter()
+                .any(|row| row.f_term[axis].map_or(false, |val| val.abs() > 1e-9))
+            {
                 has_nonzero_f_term_data[axis] = true;
             }
         }
@@ -133,85 +167,135 @@ fn process_file(input_file_str: &str, setpoint_threshold: f64, show_legend: bool
         }
     }
 
-    if let (Some(first_time_val), Some(last_time_val), Some(_sr_val_check)) = (first_time, last_time, sample_rate) { // Renamed _sr to _sr_val_check to avoid conflict
-         if required_headers_for_sr_input {
-             for row in &all_log_data {
-                 if let (Some(time), Some(setpoint_roll), Some(gyro_roll),
-                         Some(setpoint_pitch), Some(gyro_pitch),
-                         Some(setpoint_yaw), Some(gyro_yaw)) = (
-                     row.time_sec, row.setpoint[0], row.gyro[0],
-                     row.setpoint[1], row.gyro[1],
-                     row.setpoint[2], row.gyro[2],
-                 ) {
-                     if time >= first_time_val + EXCLUDE_START_S && time <= last_time_val - EXCLUDE_END_S {
-                         contiguous_sr_input_data[0].0.push(time); contiguous_sr_input_data[0].1.push(setpoint_roll as f32); contiguous_sr_input_data[0].2.push(gyro_roll as f32);
-                         contiguous_sr_input_data[1].0.push(time); contiguous_sr_input_data[1].1.push(setpoint_pitch as f32); contiguous_sr_input_data[1].2.push(gyro_pitch as f32);
-                         contiguous_sr_input_data[2].0.push(time); contiguous_sr_input_data[2].1.push(setpoint_yaw as f32); contiguous_sr_input_data[2].2.push(gyro_yaw as f32);
-                     }
-                 }
-             }
-         } else {
-              println!("
-INFO ({}): Skipping Step Response data collection: Setpoint or Gyro headers missing.", input_file_str);
-         }
+    if let (Some(first_time_val), Some(last_time_val), Some(_sr_val_check)) =
+        (first_time, last_time, sample_rate)
+    {
+        // Renamed _sr to _sr_val_check to avoid conflict
+        if required_headers_for_sr_input {
+            for row in &all_log_data {
+                if let (
+                    Some(time),
+                    Some(setpoint_roll),
+                    Some(gyro_roll),
+                    Some(setpoint_pitch),
+                    Some(gyro_pitch),
+                    Some(setpoint_yaw),
+                    Some(gyro_yaw),
+                ) = (
+                    row.time_sec,
+                    row.setpoint[0],
+                    row.gyro[0],
+                    row.setpoint[1],
+                    row.gyro[1],
+                    row.setpoint[2],
+                    row.gyro[2],
+                ) {
+                    if time >= first_time_val + EXCLUDE_START_S
+                        && time <= last_time_val - EXCLUDE_END_S
+                    {
+                        contiguous_sr_input_data[0].0.push(time);
+                        contiguous_sr_input_data[0].1.push(setpoint_roll as f32);
+                        contiguous_sr_input_data[0].2.push(gyro_roll as f32);
+                        contiguous_sr_input_data[1].0.push(time);
+                        contiguous_sr_input_data[1].1.push(setpoint_pitch as f32);
+                        contiguous_sr_input_data[1].2.push(gyro_pitch as f32);
+                        contiguous_sr_input_data[2].0.push(time);
+                        contiguous_sr_input_data[2].1.push(setpoint_yaw as f32);
+                        contiguous_sr_input_data[2].2.push(gyro_yaw as f32);
+                    }
+                }
+            }
+        } else {
+            println!(
+                "
+INFO ({}): Skipping Step Response data collection: Setpoint or Gyro headers missing.",
+                input_file_str
+            );
+        }
     } else {
-         let reason = if first_time.is_none() || last_time.is_none() {
-             "Time range unknown"
-         } else {
-             "Sample Rate unknown"
-         };
-         println!("
-INFO ({}): Skipping Step Response input data filtering: {}.", input_file_str, reason);
+        let reason = if first_time.is_none() || last_time.is_none() {
+            "Time range unknown"
+        } else {
+            "Sample Rate unknown"
+        };
+        println!(
+            "
+INFO ({}): Skipping Step Response input data filtering: {}.",
+            input_file_str, reason
+        );
     }
 
-    println!("
---- Calculating Step Response for {} ---", input_file_str);
-    let mut step_response_calculation_results: [Option<(Array1<f64>, Array2<f32>, Array1<f32>)>; 3] = [None, None, None];
+    println!(
+        "
+--- Calculating Step Response for {} ---",
+        input_file_str
+    );
+    let mut step_response_calculation_results: [Option<(Array1<f64>, Array2<f32>, Array1<f32>)>;
+        3] = [None, None, None];
 
-     if let Some(sr) = sample_rate {
+    if let Some(sr) = sample_rate {
         for axis_index in 0..3 {
-            let required_headers_found = setpoint_header_found[axis_index] && gyro_header_found[axis_index];
+            let required_headers_found =
+                setpoint_header_found[axis_index] && gyro_header_found[axis_index];
             if required_headers_found && !contiguous_sr_input_data[axis_index].0.is_empty() {
-                println!("  Attempting step response calculation for Axis {}...", axis_index);
+                println!(
+                    "  Attempting step response calculation for Axis {}...",
+                    axis_index
+                );
                 let time_arr = Array1::from(contiguous_sr_input_data[axis_index].0.clone());
                 let setpoints_arr = Array1::from(contiguous_sr_input_data[axis_index].1.clone());
-                let gyros_filtered_arr = Array1::from(contiguous_sr_input_data[axis_index].2.clone());
+                let gyros_filtered_arr =
+                    Array1::from(contiguous_sr_input_data[axis_index].2.clone());
 
                 let min_required_samples = (FRAME_LENGTH_S * sr).ceil() as usize;
                 if time_arr.len() >= min_required_samples {
-                    match calc_step_response::calculate_step_response(&time_arr, &setpoints_arr, &gyros_filtered_arr, sr) {
+                    match calc_step_response::calculate_step_response(
+                        &time_arr,
+                        &setpoints_arr,
+                        &gyros_filtered_arr,
+                        sr,
+                    ) {
                         Ok(result) => {
-                             let num_qc_windows = result.1.shape()[0];
-                             if num_qc_windows > 0 {
-                                 step_response_calculation_results[axis_index] = Some(result);
-                                 println!("    ... Calculation successful for Axis {}. {} windows passed QC.", axis_index, num_qc_windows);
-                             } else {
+                            let num_qc_windows = result.1.shape()[0];
+                            if num_qc_windows > 0 {
+                                step_response_calculation_results[axis_index] = Some(result);
+                                println!("    ... Calculation successful for Axis {}. {} windows passed QC.", axis_index, num_qc_windows);
+                            } else {
                                 println!("    ... Calculation returned no valid windows for Axis {}. Skipping.", axis_index);
-                             }
+                            }
                         }
                         Err(e) => {
                             eprintln!("    ... Calculation failed for Axis {}: {}", axis_index, e);
                         }
                     }
                 } else {
-                     println!("    ... Skipping Axis {}: Not enough movement data points ({}) for windowing (need at least {}).", axis_index, time_arr.len(), min_required_samples);
+                    println!("    ... Skipping Axis {}: Not enough movement data points ({}) for windowing (need at least {}).", axis_index, time_arr.len(), min_required_samples);
                 }
             } else {
-                 let reason = if !required_headers_found {
-                     "Setpoint or Gyro headers missing"
-                 } else {
-                     "No movement-filtered input data available"
-                 };
-                 println!("  Skipping Step Response calculation for Axis {}: {}", axis_index, reason);
+                let reason = if !required_headers_found {
+                    "Setpoint or Gyro headers missing"
+                } else {
+                    "No movement-filtered input data available"
+                };
+                println!(
+                    "  Skipping Step Response calculation for Axis {}: {}",
+                    axis_index, reason
+                );
             }
         }
     } else {
-         println!("  Skipping Step Response Calculation for {}: Sample rate could not be determined.", input_file_str);
+        println!(
+            "  Skipping Step Response Calculation for {}: Sample rate could not be determined.",
+            input_file_str
+        );
     }
 
     // --- Generate Plots ---
-    println!("Generating plots for {} (root name: {})...", input_file_str, root_name_string);
-    
+    println!(
+        "Generating plots for {} (root name: {})...",
+        input_file_str, root_name_string
+    );
+
     // Set the current working directory to the output directory if specified
     let original_dir = std::env::current_dir()?;
     if let Some(output_dir) = output_dir {
@@ -220,12 +304,19 @@ INFO ({}): Skipping Step Response input data filtering: {}.", input_file_str, re
         // Change to output directory for plot generation
         std::env::set_current_dir(output_dir)?;
     }
-    
+
     // Use only the root filename (without path) for PNG output
     plot_pidsum_error_setpoint(&all_log_data, &root_name_string)?;
     plot_setpoint_vs_gyro(&all_log_data, &root_name_string, sample_rate)?;
     plot_gyro_vs_unfilt(&all_log_data, &root_name_string, sample_rate)?;
-    plot_step_response(&step_response_calculation_results, &root_name_string, sample_rate, &has_nonzero_f_term_data, setpoint_threshold, show_legend)?;
+    plot_step_response(
+        &step_response_calculation_results,
+        &root_name_string,
+        sample_rate,
+        &has_nonzero_f_term_data,
+        setpoint_threshold,
+        show_legend,
+    )?;
     plot_gyro_spectrums(&all_log_data, &root_name_string, sample_rate)?;
     plot_psd(&all_log_data, &root_name_string, sample_rate)?;
     plot_psd_db_heatmap(&all_log_data, &root_name_string, sample_rate)?;
@@ -238,13 +329,12 @@ INFO ({}): Skipping Step Response input data filtering: {}.", input_file_str, re
     Ok(())
 }
 
-
 fn main() -> Result<(), Box<dyn Error>> {
     // --- Argument Parsing ---
     let args: Vec<String> = env::args().collect();
     let program_name = &args[0];
 
-    if args.len() < 2 { 
+    if args.len() < 2 {
         print_usage_and_exit(program_name);
     }
 
@@ -252,6 +342,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut setpoint_threshold_override: Option<f64> = None;
     let mut dps_flag_present = false;
     let mut output_dir: Option<String> = None; // None = not specified (use source folder), Some(dir) = --output-dir with value
+    let mut debug_mode = false;
 
     let mut i = 1;
     while i < args.len() {
@@ -277,7 +368,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         print_usage_and_exit(program_name);
                     }
                     setpoint_threshold_override = Some(val);
-                    i += 1; 
+                    i += 1;
                 }
                 Err(_) => {
                     eprintln!("Error: Invalid numeric value for --dps: {}", args[i + 1]);
@@ -295,8 +386,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             } else {
                 // --output-dir with directory value
                 output_dir = Some(args[i + 1].clone());
-                i += 1; 
-            } 
+                i += 1;
+            }
+        } else if arg == "--debug" {
+            debug_mode = true;
         } else if arg.starts_with("--") {
             eprintln!("Error: Unknown option '{}'", arg);
             print_usage_and_exit(program_name);
@@ -324,9 +417,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut use_dir_prefix_for_root_name = false;
     if input_files.len() > 1 {
-        let parent_dirs_set: HashSet<PathBuf> = input_files.iter().filter_map(|f_str| {
-            Path::new(f_str).parent().map(|p| p.to_path_buf())
-        }).collect();
+        let parent_dirs_set: HashSet<PathBuf> = input_files
+            .iter()
+            .filter_map(|f_str| Path::new(f_str).parent().map(|p| p.to_path_buf()))
+            .collect();
         if parent_dirs_set.len() > 1 {
             use_dir_prefix_for_root_name = true;
         }
@@ -339,28 +433,42 @@ fn main() -> Result<(), Box<dyn Error>> {
             None => {
                 // No --output-dir specified, use input file's directory (source folder)
                 Path::new(input_file_str).parent().and_then(|p| p.to_str())
-            },
+            }
             Some(dir) => Some(dir.as_str()), // --output-dir with specific directory
         };
-        
-        if let Err(e) = process_file(input_file_str, setpoint_threshold, show_legend, use_dir_prefix_for_root_name, actual_output_dir) {
-            eprintln!("An error occurred while processing {}: {}", input_file_str, e);
+
+        if let Err(e) = process_file(
+            input_file_str,
+            setpoint_threshold,
+            show_legend,
+            use_dir_prefix_for_root_name,
+            actual_output_dir,
+            debug_mode,
+        ) {
+            eprintln!(
+                "An error occurred while processing {}: {}",
+                input_file_str, e
+            );
             overall_success = false;
         }
     }
 
     if overall_success {
-        println!("
-All files processed successfully.");
+        println!(
+            "
+All files processed successfully."
+        );
         Ok(())
     } else {
-        eprintln!("
-Some files could not be processed successfully.");
+        eprintln!(
+            "
+Some files could not be processed successfully."
+        );
         // Still return Ok(()) here as we've handled errors per file.
         // Or, could return a generic error if preferred for the whole batch.
         // For now, exiting with 0 if any file succeeded, or if all failed but were handled.
         // To signal overall failure to scripts, one might `std::process::exit(1)` here.
-        Ok(()) 
+        Ok(())
     }
 }
 


### PR DESCRIPTION
- Add support for Type 1: separate .headers.csv files
- Add support for Type 2: embedded headers in CSV files
- Add --debug flag to control metadata output verbosity
- Implement consistent terminology: 'header metadata' vs 'flight data keys'
- Add read_headers_csv() helper function for Type 1 files
- Update parse_log_file() to handle both header types with debug mode
- Simplify output format to indicate source type clearly
- Maintain backward compatibility with existing functionality


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added --debug flag for verbose logging.
  * Support for header metadata from separate .headers.csv files and embedded headers.
  * Automatic sample rate estimation from timestamps.

* Improvements
  * More robust CSV/header detection with clear errors for missing essentials.
  * Continues processing remaining files if some inputs are missing.
  * Ensures output directory exists and uses it for outputs.
  * Sanitized output name prefixes derived from parent directory.
  * Clearer info/debug messages throughout processing.
  * More resilient step-response extraction.
  * Expanded plotting pipeline touchpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->