### PR TITLE
feat: Add comprehensive PID metadata parsing and display support

### DIFF
--- a/src/data_input/mod.rs
+++ b/src/data_input/mod.rs
@@ -2,5 +2,6 @@
 
 pub mod log_data;
 pub mod log_parser;
+pub mod pid_metadata;
 
 // src/data_input/mod.rs

--- a/src/data_input/pid_metadata.rs
+++ b/src/data_input/pid_metadata.rs
@@ -1,18 +1,13 @@
 // src/data_input/pid_metadata.rs
 
 /// Firmware type detection for appropriate terminology
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub enum FirmwareType {
     Betaflight,
     EmuFlight,
     Inav,
+    #[default]
     Unknown,
-}
-
-impl Default for FirmwareType {
-    fn default() -> Self {
-        FirmwareType::Unknown
-    }
 }
 
 /// PID values for a single axis
@@ -40,20 +35,28 @@ impl AxisPid {
         
         // Handle D, D-Min, and D-Max formatting
         match (self.d, self.d_min, self.d_max) {
-            (_, Some(d_min), Some(d_max)) if d_min != d_max => {
-                // Show D:min/max format when D-Min and D-Max are different
+            (_, Some(d_min), Some(d_max)) if d_min != d_max && d_min > 0 && d_max > 0 => {
+                // Show D:min/max format when D-Min and D-Max are different and both non-zero
                 parts.push(format!("D:{}/{}", d_min, d_max));
+            }
+            (_, Some(d_min), Some(d_max)) if d_min != d_max && d_min > 0 && d_max == 0 => {
+                // Show D:min format when D-Max is zero (don't show /0)
+                parts.push(format!("D:{}", d_min));
+            }
+            (_, Some(d_min), Some(d_max)) if d_min != d_max && d_min == 0 && d_max > 0 => {
+                // Show D:max format when D-Min is zero (don't show 0/)
+                parts.push(format!("D:{}", d_max));
             }
             (Some(d), Some(_d_min), Some(_d_max)) => {
                 // Show D:XX format when D-Min and D-Max are the same (use actual D value)
                 parts.push(format!("D:{}", d));
             }
-            (Some(d), None, Some(d_max)) if d != d_max => {
-                // Show D:XX/XX format when only D-Max is available and different from D
+            (Some(d), None, Some(d_max)) if d != d_max && d_max > 0 => {
+                // Show D:XX/XX format when only D-Max is available, different from D, and non-zero
                 parts.push(format!("D:{}/{}", d, d_max));
             }
             (Some(d), _, _) => {
-                // Show simple D:XX when no D-Min/D-Max or they're the same as D
+                // Show simple D:XX when no D-Min/D-Max, they're the same as D, or involve zeros
                 parts.push(format!("D:{}", d));
             }
             _ => {}
@@ -88,12 +91,13 @@ pub struct PidMetadata {
 
 impl PidMetadata {
     /// Get PID data for a specific axis (0=roll, 1=pitch, 2=yaw)
-    pub fn get_axis(&self, axis_index: usize) -> &AxisPid {
+    /// Returns None if axis_index is invalid (not 0, 1, or 2)
+    pub fn get_axis(&self, axis_index: usize) -> Option<&AxisPid> {
         match axis_index {
-            0 => &self.roll,
-            1 => &self.pitch,
-            2 => &self.yaw,
-            _ => panic!("Invalid axis index: {}. Expected 0 (roll), 1 (pitch), or 2 (yaw)", axis_index),
+            0 => Some(&self.roll),
+            1 => Some(&self.pitch),
+            2 => Some(&self.yaw),
+            _ => None,
         }
     }
     
@@ -107,7 +111,7 @@ impl PidMetadata {
 fn detect_firmware_type(header_map: &std::collections::HashMap<String, String>) -> FirmwareType {
     // Check for firmware revision field (primary detection method)
     if let Some(firmware_rev) = header_map.get("firmware revision") {
-        let normalized_rev = firmware_rev.to_lowercase().trim().to_string();
+        let normalized_rev = firmware_rev.trim().to_lowercase();
         if normalized_rev.contains("emuflight") {
             return FirmwareType::EmuFlight;
         }
@@ -121,7 +125,7 @@ fn detect_firmware_type(header_map: &std::collections::HashMap<String, String>) 
     
     // Fallback: Check for firmware type field (secondary, if revision missing)
     if let Some(firmware_type) = header_map.get("firmware type") {
-        let normalized_type = firmware_type.to_lowercase().trim().to_string();
+        let normalized_type = firmware_type.trim().to_lowercase();
         if normalized_type.contains("emuflight") {
             return FirmwareType::EmuFlight;
         }
@@ -145,6 +149,98 @@ fn detect_firmware_type(header_map: &std::collections::HashMap<String, String>) 
     FirmwareType::Unknown
 }
 
+/// Helper function to parse D-Min or D-Max values for all axes
+fn parse_d_values(
+    header_map: &std::collections::HashMap<String, String>,
+    comma_separated_key: &str,
+    individual_keys: [&str; 6], // [roll_key1, roll_key2, pitch_key1, pitch_key2, yaw_key1, yaw_key2]
+) -> [Option<u32>; 3] {
+    let mut values = [None; 3];
+    
+    // Try comma-separated format first
+    if let Some(value_str) = header_map.get(comma_separated_key) {
+        let parsed_values = parse_comma_separated_values(value_str);
+        if parsed_values.len() >= 3 {
+            values[0] = Some(parsed_values[0]);
+            values[1] = Some(parsed_values[1]);
+            values[2] = Some(parsed_values[2]);
+            return values;
+        }
+    }
+    
+    // Fallback to individual fields
+    for axis in 0..3 {
+        let key1 = individual_keys[axis * 2];
+        let key2 = individual_keys[axis * 2 + 1];
+        
+        if let Some(value_str) = header_map.get(key1).or_else(|| header_map.get(key2)) {
+            if let Ok(value) = value_str.parse::<u32>() {
+                values[axis] = Some(value);
+            }
+        }
+    }
+    
+    values
+}
+
+/// Helper function to parse FF values for all axes
+fn parse_ff_values(
+    header_map: &std::collections::HashMap<String, String>,
+    existing_pids: &(AxisPid, AxisPid, AxisPid),
+) -> [Option<u32>; 3] {
+    let mut ff_values = [
+        existing_pids.0.ff, // Roll FF from PID string
+        existing_pids.1.ff, // Pitch FF from PID string
+        existing_pids.2.ff, // Yaw FF from PID string
+    ];
+    
+    // Betaflight style: ff_weight with roll,pitch,yaw values (overrides PID string FF)
+    if let Some(ff_weight_str) = header_map.get("ff_weight") {
+        let values = parse_comma_separated_values(ff_weight_str);
+        if values.len() >= 3 {
+            for (i, &value) in values.iter().enumerate().take(3) {
+                if value > 0 {
+                    ff_values[i] = Some(value);
+                }
+            }
+        }
+    }
+    
+    // Emuflight style: df_yaw for yaw feedforward only (overrides PID string FF for yaw)
+    if let Some(df_yaw_str) = header_map.get("df_yaw") {
+        if let Ok(df_yaw_val) = df_yaw_str.parse::<u32>() {
+            if df_yaw_val > 0 {
+                ff_values[2] = Some(df_yaw_val); // Yaw is index 2
+            }
+        }
+    }
+    
+    ff_values
+}
+
+/// Helper function to parse axis PID values from header map
+fn parse_axis_pids(header_map: &std::collections::HashMap<String, String>) -> (AxisPid, AxisPid, AxisPid) {
+    let roll = if let Some(roll_pid_str) = header_map.get("rollpid") {
+        parse_axis_pid(roll_pid_str)
+    } else {
+        AxisPid::default()
+    };
+    
+    let pitch = if let Some(pitch_pid_str) = header_map.get("pitchpid") {
+        parse_axis_pid(pitch_pid_str)
+    } else {
+        AxisPid::default()
+    };
+    
+    let yaw = if let Some(yaw_pid_str) = header_map.get("yawpid") {
+        parse_axis_pid(yaw_pid_str)
+    } else {
+        AxisPid::default()
+    };
+    
+    (roll, pitch, yaw)
+}
+
 /// Parse PID metadata from header key-value pairs
 /// Supports Betaflight, Emuflight, and INAV formats
 /// Returns default/empty values if no metadata is available
@@ -165,100 +261,50 @@ pub fn parse_pid_metadata(header_metadata: &[(String, String)]) -> PidMetadata {
     // Detect firmware type using the same map
     pid_data.firmware_type = detect_firmware_type(&header_map);
     
-    // Parse roll PID
-    if let Some(roll_pid_str) = header_map.get("rollpid") {
-        pid_data.roll = parse_axis_pid(roll_pid_str);
-    }
-    
-    // Parse pitch PID
-    if let Some(pitch_pid_str) = header_map.get("pitchpid") {
-        pid_data.pitch = parse_axis_pid(pitch_pid_str);
-    }
-    
-    // Parse yaw PID
-    if let Some(yaw_pid_str) = header_map.get("yawpid") {
-        pid_data.yaw = parse_axis_pid(yaw_pid_str);
-    }
+    // Parse axis PID values
+    let (roll, pitch, yaw) = parse_axis_pids(&header_map);
+    pid_data.roll = roll;
+    pid_data.pitch = pitch;
+    pid_data.yaw = yaw;
     
     // Handle FF values based on flight controller type
-    
-    // Betaflight style: ff_weight with roll,pitch,yaw values
-    if let Some(ff_weight_str) = header_map.get("ff_weight") {
-        let ff_values = parse_comma_separated_values(ff_weight_str);
-        if ff_values.len() >= 3 {
-            if ff_values[0] > 0 {
-                pid_data.roll.ff = Some(ff_values[0]);
-            }
-            if ff_values[1] > 0 {
-                pid_data.pitch.ff = Some(ff_values[1]);
-            }
-            if ff_values[2] > 0 {
-                pid_data.yaw.ff = Some(ff_values[2]);
-            }
-        }
-    }
-    
-    // Emuflight style: df_yaw for yaw feedforward only
-    if let Some(df_yaw_str) = header_map.get("df_yaw") {
-        if let Ok(df_yaw_val) = df_yaw_str.parse::<u32>() {
-            if df_yaw_val > 0 {
-                pid_data.yaw.ff = Some(df_yaw_val);
-            }
-        }
-    }
+    let ff_values = parse_ff_values(&header_map, &(pid_data.roll.clone(), pid_data.pitch.clone(), pid_data.yaw.clone()));
+    pid_data.roll.ff = ff_values[0];
+    pid_data.pitch.ff = ff_values[1];
+    pid_data.yaw.ff = ff_values[2];
     
     // Look for separate D-Min fields in header metadata (Betaflight separate headers)
-    // Handle both comma-separated format "39,44,0" and individual fields
-    if let Some(d_min_str) = header_map.get("d_min") {
-        let d_min_values = parse_comma_separated_values(d_min_str);
-        if d_min_values.len() >= 3 {
-            pid_data.roll.d_min = Some(d_min_values[0]);
-            pid_data.pitch.d_min = Some(d_min_values[1]);
-            pid_data.yaw.d_min = Some(d_min_values[2]);
-        }
+    // Only override PID string D-Min values if separate fields exist
+    let d_min_values = parse_d_values(
+        &header_map,
+        "d_min",
+        ["rolldmin", "roll_d_min", "pitchdmin", "pitch_d_min", "yawdmin", "yaw_d_min"],
+    );
+    if d_min_values[0].is_some() {
+        pid_data.roll.d_min = d_min_values[0];
     }
-    
-    // Look for individual D-Min fields as fallback
-    if let Some(roll_d_min_str) = header_map.get("rolldmin").or_else(|| header_map.get("roll_d_min")) {
-        if let Ok(d_min_val) = roll_d_min_str.parse::<u32>() {
-            pid_data.roll.d_min = Some(d_min_val);
-        }
+    if d_min_values[1].is_some() {
+        pid_data.pitch.d_min = d_min_values[1];
     }
-    if let Some(pitch_d_min_str) = header_map.get("pitchdmin").or_else(|| header_map.get("pitch_d_min")) {
-        if let Ok(d_min_val) = pitch_d_min_str.parse::<u32>() {
-            pid_data.pitch.d_min = Some(d_min_val);
-        }
-    }
-    if let Some(yaw_d_min_str) = header_map.get("yawdmin").or_else(|| header_map.get("yaw_d_min")) {
-        if let Ok(d_min_val) = yaw_d_min_str.parse::<u32>() {
-            pid_data.yaw.d_min = Some(d_min_val);
-        }
+    if d_min_values[2].is_some() {
+        pid_data.yaw.d_min = d_min_values[2];
     }
     
     // Look for separate D-Max fields in header metadata (newer Betaflight separate headers)
-    // Handle both comma-separated format and individual fields
-    if let Some(d_max_str) = header_map.get("d_max") {
-        let d_max_values = parse_comma_separated_values(d_max_str);
-        if d_max_values.len() >= 3 {
-            pid_data.roll.d_max = Some(d_max_values[0]);
-            pid_data.pitch.d_max = Some(d_max_values[1]);
-            pid_data.yaw.d_max = Some(d_max_values[2]);
-        }
+    // Only override PID string D-Max values if separate fields exist
+    let d_max_values = parse_d_values(
+        &header_map,
+        "d_max",
+        ["rolldmax", "roll_d_max", "pitchdmax", "pitch_d_max", "yawdmax", "yaw_d_max"],
+    );
+    if d_max_values[0].is_some() {
+        pid_data.roll.d_max = d_max_values[0];
     }
-    if let Some(roll_d_max_str) = header_map.get("rolldmax").or_else(|| header_map.get("roll_d_max")) {
-        if let Ok(d_max_val) = roll_d_max_str.parse::<u32>() {
-            pid_data.roll.d_max = Some(d_max_val);
-        }
+    if d_max_values[1].is_some() {
+        pid_data.pitch.d_max = d_max_values[1];
     }
-    if let Some(pitch_d_max_str) = header_map.get("pitchdmax").or_else(|| header_map.get("pitch_d_max")) {
-        if let Ok(d_max_val) = pitch_d_max_str.parse::<u32>() {
-            pid_data.pitch.d_max = Some(d_max_val);
-        }
-    }
-    if let Some(yaw_d_max_str) = header_map.get("yawdmax").or_else(|| header_map.get("yaw_d_max")) {
-        if let Ok(d_max_val) = yaw_d_max_str.parse::<u32>() {
-            pid_data.yaw.d_max = Some(d_max_val);
-        }
+    if d_max_values[2].is_some() {
+        pid_data.yaw.d_max = d_max_values[2];
     }
     
     pid_data
@@ -452,15 +498,24 @@ mod tests {
         
         assert_eq!(pid_data.yaw.d_min, Some(0));
         assert_eq!(pid_data.yaw.d_max, Some(0));
+        
+        // VERIFY D:XX/XX FORMATTING IS WORKING
+        let roll_formatted = pid_data.roll.format_for_title(&FirmwareType::Betaflight);
+        assert_eq!(roll_formatted, " - P:57 I:66 D:39/80 FF:206");
+        
+        let pitch_formatted = pid_data.pitch.format_for_title(&FirmwareType::Betaflight);
+        assert_eq!(pitch_formatted, " - P:59 I:69 D:44/90 FF:215");
     }
 
     #[test]
     fn test_format_for_title() {
-        let mut axis_pid = AxisPid::default();
-        axis_pid.p = Some(31);
-        axis_pid.i = Some(56);
-        axis_pid.d = Some(21);
-        axis_pid.ff = Some(84);
+        let axis_pid = AxisPid {
+            p: Some(31),
+            i: Some(56),
+            d: Some(21),
+            ff: Some(84),
+            ..Default::default()
+        };
         
         // Test Betaflight formatting
         assert_eq!(axis_pid.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21 FF:84");
@@ -469,29 +524,115 @@ mod tests {
         assert_eq!(axis_pid.format_for_title(&FirmwareType::EmuFlight), " - P:31 I:56 D:21 DF:84");
         
         // Test with zero FF (should be omitted)
-        axis_pid.ff = Some(0);
-        assert_eq!(axis_pid.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21");
+        let axis_pid_zero_ff = AxisPid {
+            p: Some(31),
+            i: Some(56),
+            d: Some(21),
+            ff: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(axis_pid_zero_ff.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21");
         
         // Test with no FF
-        axis_pid.ff = None;
-        assert_eq!(axis_pid.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21");
+        let axis_pid_no_ff = AxisPid {
+            p: Some(31),
+            i: Some(56),
+            d: Some(21),
+            ff: None,
+            ..Default::default()
+        };
+        assert_eq!(axis_pid_no_ff.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21");
         
         // Test D:XX/XX format when D and D-Max are different
-        axis_pid.d_max = Some(35);
-        assert_eq!(axis_pid.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21/35");
+        let axis_pid_diff_dmax = AxisPid {
+            p: Some(31),
+            i: Some(56),
+            d: Some(21),
+            d_max: Some(35),
+            ff: None,
+            ..Default::default()
+        };
+        assert_eq!(axis_pid_diff_dmax.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21/35");
         
         // Test D:XX format when D and D-Max are the same
-        axis_pid.d_max = Some(21);
-        assert_eq!(axis_pid.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21");
+        let axis_pid_same_dmax = AxisPid {
+            p: Some(31),
+            i: Some(56),
+            d: Some(21),
+            d_max: Some(21),
+            ff: None,
+            ..Default::default()
+        };
+        assert_eq!(axis_pid_same_dmax.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21");
         
         // Test D:min/max format when D-Min and D-Max are different
-        axis_pid.d_min = Some(15);
-        axis_pid.d_max = Some(35);
-        assert_eq!(axis_pid.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:15/35");
+        let axis_pid_dmin_dmax = AxisPid {
+            p: Some(31),
+            i: Some(56),
+            d: Some(21),
+            d_min: Some(15),
+            d_max: Some(35),
+            ff: None,
+        };
+        assert_eq!(axis_pid_dmin_dmax.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:15/35");
         
         // Test D:min/max format with FF
-        axis_pid.ff = Some(84);
-        assert_eq!(axis_pid.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:15/35 FF:84");
+        let axis_pid_dmin_dmax_ff = AxisPid {
+            p: Some(31),
+            i: Some(56),
+            d: Some(21),
+            d_min: Some(15),
+            d_max: Some(35),
+            ff: Some(84),
+        };
+        assert_eq!(axis_pid_dmin_dmax_ff.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:15/35 FF:84");
+    }
+
+    #[test]
+    fn test_format_for_title_zero_handling() {
+        // Test D:XX/0 should become D:XX (don't show /0)
+        let axis_pid_dmax_zero = AxisPid {
+            p: Some(31),
+            i: Some(56),
+            d: Some(21),
+            d_min: Some(15),
+            d_max: Some(0), // D-Max is zero
+            ff: None,
+        };
+        assert_eq!(axis_pid_dmax_zero.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:15");
+        
+        // Test 0/XX should become D:XX (don't show 0/)
+        let axis_pid_dmin_zero = AxisPid {
+            p: Some(31),
+            i: Some(56),
+            d: Some(21),
+            d_min: Some(0), // D-Min is zero
+            d_max: Some(35),
+            ff: None,
+        };
+        assert_eq!(axis_pid_dmin_zero.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:35");
+        
+        // Test D:XX/0 with only D-Max (no D-Min) should become D:XX
+        let axis_pid_only_dmax_zero = AxisPid {
+            p: Some(31),
+            i: Some(56),
+            d: Some(21),
+            d_min: None,
+            d_max: Some(0), // D-Max is zero
+            ff: None,
+        };
+        assert_eq!(axis_pid_only_dmax_zero.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21");
+        
+        // Test normal case still works (both non-zero and different)
+        let axis_pid_normal = AxisPid {
+            p: Some(31),
+            i: Some(56),
+            d: Some(21),
+            d_min: Some(15),
+            d_max: Some(35),
+            ff: None,
+        };
+        assert_eq!(axis_pid_normal.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:15/35");
     }
 
     #[test]

--- a/src/data_input/pid_metadata.rs
+++ b/src/data_input/pid_metadata.rs
@@ -1,0 +1,348 @@
+// src/data_input/pid_metadata.rs
+
+/// Firmware type detection for appropriate terminology
+#[derive(Debug, Clone, PartialEq)]
+pub enum FirmwareType {
+    Betaflight,
+    EmuFlight,
+    Inav,
+    Unknown,
+}
+
+impl Default for FirmwareType {
+    fn default() -> Self {
+        FirmwareType::Unknown
+    }
+}
+
+/// PID values for a single axis
+#[derive(Debug, Clone, Default)]
+pub struct AxisPid {
+    pub p: Option<u32>,
+    pub i: Option<u32>,
+    pub d: Option<u32>,
+    pub ff: Option<u32>,
+}
+
+impl AxisPid {
+    /// Format PID values for display with firmware-specific terminology
+    pub fn format_for_title(&self, firmware_type: &FirmwareType) -> String {
+        let mut parts = Vec::new();
+        
+        if let Some(p) = self.p {
+            parts.push(format!("P:{}", p));
+        }
+        if let Some(i) = self.i {
+            parts.push(format!("I:{}", i));
+        }
+        if let Some(d) = self.d {
+            parts.push(format!("D:{}", d));
+        }
+        if let Some(ff) = self.ff {
+            if ff > 0 {
+                let ff_label = match firmware_type {
+                    FirmwareType::EmuFlight => "DF",
+                    _ => "FF",
+                };
+                parts.push(format!("{}:{}", ff_label, ff));
+            }
+        }
+        
+        if parts.is_empty() {
+            String::new()
+        } else {
+            format!(" - {}", parts.join(" "))
+        }
+    }
+}
+
+/// PID metadata for all three axes (Roll, Pitch, Yaw) with firmware type
+#[derive(Debug, Clone, Default)]
+pub struct PidMetadata {
+    pub roll: AxisPid,   // Axis 0
+    pub pitch: AxisPid,  // Axis 1
+    pub yaw: AxisPid,    // Axis 2
+    pub firmware_type: FirmwareType,
+}
+
+impl PidMetadata {
+    /// Get PID data for a specific axis (0=roll, 1=pitch, 2=yaw)
+    pub fn get_axis(&self, axis_index: usize) -> &AxisPid {
+        match axis_index {
+            0 => &self.roll,
+            1 => &self.pitch,
+            2 => &self.yaw,
+            _ => &self.roll, // Default to roll for invalid indices
+        }
+    }
+    
+    /// Get firmware type
+    pub fn get_firmware_type(&self) -> &FirmwareType {
+        &self.firmware_type
+    }
+}
+
+/// Detect firmware type from header metadata
+fn detect_firmware_type(header_metadata: &[(String, String)]) -> FirmwareType {
+    let header_map: std::collections::HashMap<String, String> = header_metadata
+        .iter()
+        .map(|(k, v)| (k.to_lowercase(), v.to_lowercase()))
+        .collect();
+    
+    // Check for firmware revision field
+    if let Some(firmware_rev) = header_map.get("firmware revision") {
+        if firmware_rev.contains("emuflight") {
+            return FirmwareType::EmuFlight;
+        }
+        if firmware_rev.contains("betaflight") {
+            return FirmwareType::Betaflight;
+        }
+        if firmware_rev.contains("inav") {
+            return FirmwareType::Inav;
+        }
+    }
+    
+    // Check for firmware type field
+    if let Some(firmware_type) = header_map.get("firmware type") {
+        if firmware_type.contains("emuflight") {
+            return FirmwareType::EmuFlight;
+        }
+        if firmware_type.contains("betaflight") {
+            return FirmwareType::Betaflight;
+        }
+        if firmware_type.contains("inav") {
+            return FirmwareType::Inav;
+        }
+    }
+    
+    // Check for EmuFlight-specific fields
+    if header_map.contains_key("df_yaw") {
+        return FirmwareType::EmuFlight;
+    }
+    
+    // Check for Betaflight-specific fields  
+    if header_map.contains_key("ff_weight") {
+        return FirmwareType::Betaflight;
+    }
+    
+    FirmwareType::Unknown
+}
+
+/// Parse PID metadata from header key-value pairs
+/// Supports Betaflight, Emuflight, and INAV formats
+/// Returns default/empty values if no metadata is available
+pub fn parse_pid_metadata(header_metadata: &[(String, String)]) -> PidMetadata {
+    let mut pid_data = PidMetadata::default();
+    
+    // Detect firmware type first
+    pid_data.firmware_type = detect_firmware_type(header_metadata);
+    
+    // If no metadata available, return default (empty) values
+    if header_metadata.is_empty() {
+        return pid_data;
+    }
+    
+    // Convert header metadata to a lookup map for easier access
+    let header_map: std::collections::HashMap<String, String> = header_metadata
+        .iter()
+        .map(|(k, v)| (k.to_lowercase(), v.clone()))
+        .collect();
+    
+    // Parse roll PID
+    if let Some(roll_pid_str) = header_map.get("rollpid") {
+        pid_data.roll = parse_axis_pid(roll_pid_str);
+    }
+    
+    // Parse pitch PID
+    if let Some(pitch_pid_str) = header_map.get("pitchpid") {
+        pid_data.pitch = parse_axis_pid(pitch_pid_str);
+    }
+    
+    // Parse yaw PID
+    if let Some(yaw_pid_str) = header_map.get("yawpid") {
+        pid_data.yaw = parse_axis_pid(yaw_pid_str);
+    }
+    
+    // Handle FF values based on flight controller type
+    
+    // Betaflight style: ff_weight with roll,pitch,yaw values
+    if let Some(ff_weight_str) = header_map.get("ff_weight") {
+        let ff_values = parse_comma_separated_values(ff_weight_str);
+        if ff_values.len() >= 3 {
+            if ff_values[0] > 0 {
+                pid_data.roll.ff = Some(ff_values[0]);
+            }
+            if ff_values[1] > 0 {
+                pid_data.pitch.ff = Some(ff_values[1]);
+            }
+            if ff_values[2] > 0 {
+                pid_data.yaw.ff = Some(ff_values[2]);
+            }
+        }
+    }
+    
+    // Emuflight style: df_yaw for yaw feedforward only
+    if let Some(df_yaw_str) = header_map.get("df_yaw") {
+        if let Ok(df_yaw_val) = df_yaw_str.parse::<u32>() {
+            if df_yaw_val > 0 {
+                pid_data.yaw.ff = Some(df_yaw_val);
+            }
+        }
+    }
+    
+    pid_data
+}
+
+/// Parse PID values from a string like "31,56,21" or "45,80,40,120" (INAV with FF)
+fn parse_axis_pid(pid_str: &str) -> AxisPid {
+    let values = parse_comma_separated_values(pid_str);
+    
+    let mut axis_pid = AxisPid::default();
+    
+    if !values.is_empty() {
+        axis_pid.p = Some(values[0]);
+    }
+    if values.len() > 1 {
+        axis_pid.i = Some(values[1]);
+    }
+    if values.len() > 2 {
+        axis_pid.d = Some(values[2]);
+    }
+    if values.len() > 3 && values[3] > 0 {
+        // INAV style with FF as 4th value
+        axis_pid.ff = Some(values[3]);
+    }
+    
+    axis_pid
+}
+
+/// Parse comma-separated values from a string
+fn parse_comma_separated_values(value_str: &str) -> Vec<u32> {
+    value_str
+        .split(',')
+        .filter_map(|s| s.trim().parse::<u32>().ok())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_betaflight_parsing() {
+        let metadata = vec![
+            ("rollPID".to_string(), "31,56,21".to_string()),
+            ("pitchPID".to_string(), "32,58,23".to_string()),
+            ("yawPID".to_string(), "31,56,0".to_string()),
+            ("ff_weight".to_string(), "84,87,84".to_string()),
+        ];
+        
+        let pid_data = parse_pid_metadata(&metadata);
+        
+        assert_eq!(pid_data.roll.p, Some(31));
+        assert_eq!(pid_data.roll.i, Some(56));
+        assert_eq!(pid_data.roll.d, Some(21));
+        assert_eq!(pid_data.roll.ff, Some(84));
+        
+        assert_eq!(pid_data.pitch.p, Some(32));
+        assert_eq!(pid_data.pitch.i, Some(58));
+        assert_eq!(pid_data.pitch.d, Some(23));
+        assert_eq!(pid_data.pitch.ff, Some(87));
+        
+        assert_eq!(pid_data.yaw.p, Some(31));
+        assert_eq!(pid_data.yaw.i, Some(56));
+        assert_eq!(pid_data.yaw.d, Some(0));
+        assert_eq!(pid_data.yaw.ff, Some(84));
+    }
+
+    #[test]
+    fn test_emuflight_parsing() {
+        let metadata = vec![
+            ("rollPID".to_string(), "52,57,38".to_string()),
+            ("pitchPID".to_string(), "62,57,44".to_string()),
+            ("yawPID".to_string(), "90,90,7".to_string()),
+            ("df_yaw".to_string(), "15".to_string()),
+        ];
+        
+        let pid_data = parse_pid_metadata(&metadata);
+        
+        assert_eq!(pid_data.roll.p, Some(52));
+        assert_eq!(pid_data.roll.i, Some(57));
+        assert_eq!(pid_data.roll.d, Some(38));
+        assert_eq!(pid_data.roll.ff, None);
+        
+        assert_eq!(pid_data.pitch.p, Some(62));
+        assert_eq!(pid_data.pitch.i, Some(57));
+        assert_eq!(pid_data.pitch.d, Some(44));
+        assert_eq!(pid_data.pitch.ff, None);
+        
+        assert_eq!(pid_data.yaw.p, Some(90));
+        assert_eq!(pid_data.yaw.i, Some(90));
+        assert_eq!(pid_data.yaw.d, Some(7));
+        assert_eq!(pid_data.yaw.ff, Some(15));
+    }
+
+    #[test]
+    fn test_inav_parsing() {
+        let metadata = vec![
+            ("rollPID".to_string(), "45,80,40,120".to_string()),
+            ("pitchPID".to_string(), "47,84,46,125".to_string()),
+            ("yawPID".to_string(), "45,80,0,120".to_string()),
+        ];
+        
+        let pid_data = parse_pid_metadata(&metadata);
+        
+        assert_eq!(pid_data.roll.p, Some(45));
+        assert_eq!(pid_data.roll.i, Some(80));
+        assert_eq!(pid_data.roll.d, Some(40));
+        assert_eq!(pid_data.roll.ff, Some(120));
+        
+        assert_eq!(pid_data.pitch.p, Some(47));
+        assert_eq!(pid_data.pitch.i, Some(84));
+        assert_eq!(pid_data.pitch.d, Some(46));
+        assert_eq!(pid_data.pitch.ff, Some(125));
+        
+        assert_eq!(pid_data.yaw.p, Some(45));
+        assert_eq!(pid_data.yaw.i, Some(80));
+        assert_eq!(pid_data.yaw.d, Some(0));
+        assert_eq!(pid_data.yaw.ff, Some(120));
+    }
+
+    #[test]
+    fn test_format_for_title() {
+        let mut axis_pid = AxisPid::default();
+        axis_pid.p = Some(31);
+        axis_pid.i = Some(56);
+        axis_pid.d = Some(21);
+        axis_pid.ff = Some(84);
+        
+        // Test Betaflight formatting
+        assert_eq!(axis_pid.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21 FF:84");
+        
+        // Test EmuFlight formatting
+        assert_eq!(axis_pid.format_for_title(&FirmwareType::EmuFlight), " - P:31 I:56 D:21 DF:84");
+        
+        // Test with zero FF (should be omitted)
+        axis_pid.ff = Some(0);
+        assert_eq!(axis_pid.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21");
+        
+        // Test with no FF
+        axis_pid.ff = None;
+        assert_eq!(axis_pid.format_for_title(&FirmwareType::Betaflight), " - P:31 I:56 D:21");
+    }
+
+    #[test]
+    fn test_empty_metadata() {
+        let empty_metadata = vec![];
+        let pid_data = parse_pid_metadata(&empty_metadata);
+        
+        // Should return default values
+        assert_eq!(pid_data.roll.p, None);
+        assert_eq!(pid_data.roll.i, None);
+        assert_eq!(pid_data.roll.d, None);
+        assert_eq!(pid_data.roll.ff, None);
+        
+        // Title should be empty
+        assert_eq!(pid_data.roll.format_for_title(&FirmwareType::Unknown), "");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ use crate::plot_functions::plot_throttle_freq_heatmap::plot_throttle_freq_heatma
 
 // Data input import
 use crate::data_input::log_parser::parse_log_file;
+use crate::data_input::pid_metadata::parse_pid_metadata;
 
 // Data analysis imports
 use crate::data_analysis::calc_step_response;
@@ -120,7 +121,7 @@ fn process_file(
         gyro_header_found,
         _gyro_unfilt_header_found,
         _debug_header_found,
-        _header_metadata,
+        header_metadata,
     ) = match parse_log_file(&input_path, debug_mode) {
         Ok(data) => data,
         Err(e) => {
@@ -137,6 +138,9 @@ fn process_file(
         return Ok(());
     }
 
+    // Parse PID metadata from headers
+    let pid_metadata = parse_pid_metadata(&header_metadata);
+    
     let mut has_nonzero_f_term_data = [false; 3];
     for axis in 0..3 {
         if f_term_header_found[axis] {
@@ -316,6 +320,7 @@ INFO ({}): Skipping Step Response input data filtering: {}.",
         &has_nonzero_f_term_data,
         setpoint_threshold,
         show_legend,
+        &pid_metadata,
     )?;
     plot_gyro_spectrums(&all_log_data, &root_name_string, sample_rate)?;
     plot_psd(&all_log_data, &root_name_string, sample_rate)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod constants;
 mod data_analysis;
 mod data_input;
+mod pid_context;
 mod plot_framework;
 mod plot_functions;
 
@@ -30,6 +31,9 @@ use crate::plot_functions::plot_throttle_freq_heatmap::plot_throttle_freq_heatma
 // Data input import
 use crate::data_input::log_parser::parse_log_file;
 use crate::data_input::pid_metadata::parse_pid_metadata;
+
+// PID context import
+use crate::pid_context::PidContext;
 
 // Data analysis imports
 use crate::data_analysis::calc_step_response;
@@ -310,6 +314,10 @@ INFO ({}): Skipping Step Response input data filtering: {}.",
     }
 
     // Use only the root filename (without path) for PNG output
+    
+    // Create PID context for centralized PID metadata and related parameters
+    let pid_context = PidContext::new(sample_rate, pid_metadata, root_name_string.clone());
+    
     plot_pidsum_error_setpoint(&all_log_data, &root_name_string)?;
     plot_setpoint_vs_gyro(&all_log_data, &root_name_string, sample_rate)?;
     plot_gyro_vs_unfilt(&all_log_data, &root_name_string, sample_rate)?;
@@ -320,7 +328,7 @@ INFO ({}): Skipping Step Response input data filtering: {}.",
         &has_nonzero_f_term_data,
         setpoint_threshold,
         show_legend,
-        &pid_metadata,
+        &pid_context.pid_metadata,
     )?;
     plot_gyro_spectrums(&all_log_data, &root_name_string, sample_rate)?;
     plot_psd(&all_log_data, &root_name_string, sample_rate)?;

--- a/src/pid_context.rs
+++ b/src/pid_context.rs
@@ -48,14 +48,18 @@ impl PidContext {
     #[allow(dead_code)] // Future use in plot functions
     pub fn get_axis_title_with_pids(&self, axis_index: usize) -> String {
         let axis_name = self.get_axis_name(axis_index);
-        let axis_pid = self.pid_metadata.get_axis(axis_index);
-        let firmware_type = self.pid_metadata.get_firmware_type();
-        let pid_info = axis_pid.format_for_title(firmware_type);
         
-        if pid_info.is_empty() {
-            axis_name.to_string()
+        if let Some(axis_pid) = self.pid_metadata.get_axis(axis_index) {
+            let firmware_type = self.pid_metadata.get_firmware_type();
+            let pid_info = axis_pid.format_for_title(firmware_type);
+            
+            if pid_info.is_empty() {
+                axis_name.to_string()
+            } else {
+                format!("{}{}", axis_name, pid_info)
+            }
         } else {
-            format!("{} ({})", axis_name, pid_info)
+            axis_name.to_string()
         }
     }
 }

--- a/src/pid_context.rs
+++ b/src/pid_context.rs
@@ -1,0 +1,61 @@
+// src/pid_context.rs
+
+use crate::data_input::pid_metadata::PidMetadata;
+
+/// Context struct containing PID metadata and related parameters for plotting functions
+/// This centralizes PID-related data and makes it easier to extend functionality
+/// without breaking existing function signatures
+#[derive(Debug, Clone)]
+pub struct PidContext {
+    /// Sample rate for time-based calculations and axis labeling
+    #[allow(dead_code)] // Future use in plot functions
+    pub sample_rate: Option<f64>,
+    
+    /// PID metadata extracted from blackbox headers (firmware type, PID values)
+    pub pid_metadata: PidMetadata,
+    
+    /// Root filename (without path/extension) for output file naming
+    #[allow(dead_code)] // Future use in plot functions
+    pub root_name: String,
+}
+
+impl PidContext {
+    /// Create a new PidContext with the provided parameters
+    pub fn new(
+        sample_rate: Option<f64>,
+        pid_metadata: PidMetadata,
+        root_name: String,
+    ) -> Self {
+        Self {
+            sample_rate,
+            pid_metadata,
+            root_name,
+        }
+    }
+    
+    /// Get axis name for display purposes
+    #[allow(dead_code)] // Future use in plot functions
+    pub fn get_axis_name(&self, axis_index: usize) -> &'static str {
+        match axis_index {
+            0 => "Roll",
+            1 => "Pitch", 
+            2 => "Yaw",
+            _ => panic!("Invalid axis index: {}. Expected 0 (roll), 1 (pitch), or 2 (yaw)", axis_index),
+        }
+    }
+    
+    /// Get firmware-specific axis title with PID information
+    #[allow(dead_code)] // Future use in plot functions
+    pub fn get_axis_title_with_pids(&self, axis_index: usize) -> String {
+        let axis_name = self.get_axis_name(axis_index);
+        let axis_pid = self.pid_metadata.get_axis(axis_index);
+        let firmware_type = self.pid_metadata.get_firmware_type();
+        let pid_info = axis_pid.format_for_title(firmware_type);
+        
+        if pid_info.is_empty() {
+            axis_name.to_string()
+        } else {
+            format!("{} ({})", axis_name, pid_info)
+        }
+    }
+}

--- a/src/plot_functions/plot_step_response.rs
+++ b/src/plot_functions/plot_step_response.rs
@@ -227,11 +227,12 @@ pub fn plot_step_response(
                     let mut title = format!("Axis {} Step Response", axis_index);
                     
                     // Add PID information to the title using firmware-specific terminology
-                    let axis_pid = pid_metadata.get_axis(axis_index);
-                    let firmware_type = pid_metadata.get_firmware_type();
-                    let pid_info = axis_pid.format_for_title(firmware_type);
-                    if !pid_info.is_empty() {
-                        title.push_str(&pid_info);
+                    if let Some(axis_pid) = pid_metadata.get_axis(axis_index) {
+                        let firmware_type = pid_metadata.get_firmware_type();
+                        let pid_info = axis_pid.format_for_title(firmware_type);
+                        if !pid_info.is_empty() {
+                            title.push_str(&pid_info);
+                        }
                     }
                     
                     // Keep original invalidity logic from master - same for all firmware types

--- a/src/plot_functions/plot_step_response.rs
+++ b/src/plot_functions/plot_step_response.rs
@@ -12,6 +12,7 @@ use crate::constants::{
     LINE_WIDTH_PLOT, FINAL_NORMALIZED_STEADY_STATE_TOLERANCE
 };
 use crate::data_analysis::calc_step_response; // For average_responses and moving_average_smooth_f64
+use crate::data_input::pid_metadata::PidMetadata;
 
 /// Generates the Stacked Step Response Plot (Blue, Orange, Red)
 pub fn plot_step_response(
@@ -21,6 +22,7 @@ pub fn plot_step_response(
     has_nonzero_f_term_data: &[bool; 3],
     setpoint_threshold: f64,
     show_legend: bool,
+    pid_metadata: &PidMetadata,
     // Add axis_index_for_debug if you uncomment debug prints in process_response
     // axis_index_for_debug: usize, // Uncomment if using debug prints
 ) -> Result<(), Box<dyn Error>> {
@@ -223,6 +225,16 @@ pub fn plot_step_response(
             plot_data_per_axis[axis_index] = Some((
                 {
                     let mut title = format!("Axis {} Step Response", axis_index);
+                    
+                    // Add PID information to the title using firmware-specific terminology
+                    let axis_pid = pid_metadata.get_axis(axis_index);
+                    let firmware_type = pid_metadata.get_firmware_type();
+                    let pid_info = axis_pid.format_for_title(firmware_type);
+                    if !pid_info.is_empty() {
+                        title.push_str(&pid_info);
+                    }
+                    
+                    // Keep original invalidity logic from master - same for all firmware types
                     if has_nonzero_f_term_data[axis_index] {
                         title.push_str(" - Invalid due Feed-Forward");
                     }


### PR DESCRIPTION
- Add new pid_metadata module with firmware type detection
- Support Betaflight, EmuFlight, and INAV PID formats
- Add firmware-specific terminology (FF vs DF for feedforward)
- Integrate PID values into step response plot titles
- Include comprehensive test coverage for all firmware types


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Firmware-aware PID metadata parsing from log headers with auto-detection of Betaflight, EmuFlight, and INAV; supports varied PID formats (P/I/D, D‑Min/D‑Max, FF/DF).
  - Centralized PID context created and passed to plotting for consistent per-axis PID access.
  - Step Response plots now annotate axis titles with firmware-specific per-axis PID info, omitting unavailable fields.
- **Tests**
  - Unit tests added for parsing, formatting, and missing-data scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->