### PR TITLE
fix: Auto-stage formatting changes in pre-commit hook

### DIFF
--- a/.github/pre-commit-hook.sh
+++ b/.github/pre-commit-hook.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Pre-commit hook to automatically format Rust code and run clippy
 # Install this by copying to .git/hooks/pre-commit and making it executable
+#
+# This hook will:
+# 1. Run cargo fmt to format code
+# 2. Automatically stage any formatting changes (prevents unstaged changes after commit)
+# 3. Verify formatting compliance
+# 4. Run clippy to check for warnings
 
 echo "🔍 Running pre-commit checks..."
 
@@ -17,7 +23,11 @@ if ! cargo fmt --all; then
     exit 1
 fi
 
-# Check if formatting is compliant
+# Auto-stage any formatting changes made by cargo fmt
+echo "📝 Staging formatting changes..."
+git add -u
+
+# Check if formatting is compliant (should pass since we just formatted)
 echo "✅ Checking formatting compliance..."
 if ! cargo fmt --all -- --check; then
     echo "❌ Code is not properly formatted after running cargo fmt!"


### PR DESCRIPTION
Problem:
- cargo fmt runs during pre-commit hook and modifies files on disk
- However, these formatting changes are not automatically staged
- This leaves unstaged modifications after a 'successful' commit
- Users see modified files even after committing, causing confusion

Solution:
- Add 'git add -u' after cargo fmt to auto-stage formatting changes
- This ensures all formatting changes are included in the current commit
- Repository stays clean after commit with no leftover modifications

Changes:
- Add auto-staging step after cargo fmt in pre-commit hook
- Update documentation to explain the new behavior
- Maintain all existing validation and error handling

This ensures atomic commits that include both user changes and automatic
formatting in a single commit, preventing the workflow disruption of
having unstaged changes after supposedly successful commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a Git pre-commit hook for Rust projects that auto-formats code, verifies formatting, and runs lint checks before commits. Commits are blocked on failures, with clear status messages to guide fixes.
* **Documentation**
  * Added an inline description explaining the hook’s behavior and how it affects the commit process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->