### PR TITLE
fix: skip non-CSV input files during batch processing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -466,6 +466,11 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let mut overall_success = true;
     for input_file_str in &input_files {
+        // Only process files with .csv extension (case-insensitive)
+        if !input_file_str.to_lowercase().ends_with(".csv") {
+            println!("Skipping non-CSV file: {input_file_str}");
+            continue;
+        }
         // Determine the actual output directory for this file
         let actual_output_dir = match &output_dir {
             None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -467,7 +467,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut overall_success = true;
     for input_file_str in &input_files {
         // Only process files with .csv extension (case-insensitive)
-        if !input_file_str.to_lowercase().ends_with(".csv") {
+        let is_csv = Path::new(input_file_str)
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|ext| ext.eq_ignore_ascii_case("csv"))
+            .unwrap_or(false);
+        if !is_csv {
             println!("Skipping non-CSV file: {input_file_str}");
             continue;
         }


### PR DESCRIPTION
Add a check in the main input file loop to skip any file that does not have a .csv extension (case-insensitive). This prevents accidental processing of non-CSV files (e.g., .bbl), improving robustness and user feedback. A message is printed for each skipped file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Application now processes only CSV files (case-insensitive), skipping other file types automatically.
  * When a non-CSV input is skipped, a clear diagnostic message is shown so users know which files were ignored.

* **Bug Fixes**
  * Prevents unintended processing of unsupported file types by enforcing CSV-only handling, improving reliability and reducing errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->