### PR TITLE
feat: --butterworth parameter: renders the PT2,3,4 separately in gray

### DIFF
--- a/Overview.md
+++ b/Overview.md
@@ -82,6 +82,14 @@ All analysis parameters, thresholds, plot dimensions, and algorithmic constants 
 **Filter Response Curves (`src/data_analysis/filter_response.rs`):**
 
 *   **Flight Firmware Integration:** Automatically detects and parses filter configurations from Betaflight, EmuFlight, and INAV blackbox headers including filter types (PT1, PT2, PT3, PT4, BIQUAD), cutoff frequencies, and dynamic filter ranges.
+*   **Butterworth Correction Visualization (Optional):** When enabled with the `--butterworth` command-line parameter, displays per-stage PT1 implementation details for PT2/PT3/PT4 filters on gyro and D-term spectrum plots:
+    *   PT2/PT3/PT4 filters are implemented as cascaded PT1 stages with Butterworth correction factors (PT2: 1.554×, PT3: 1.961×, PT4: 2.299×)
+    *   Main curves (colored) show user-configured filter response (e.g., "LPF1 (PT2 @ 90Hz)")
+    *   Per-stage curves (gray, prefixed with ≈) show actual PT1 implementation (e.g., "≈ LPF1 (Two PT1 @ 140Hz per-stage)")
+    *   Vertical cutoff lines: solid for configured cutoff, dotted for per-stage cutoff
+    *   Formula: per-stage cutoff = configured cutoff × correction factor
+    *   Applies to all firmware (Betaflight, EmuFlight, INAV) using PT2/PT3/PT4 filters
+    *   IMUF configurations include version information when available (e.g., "IMUF v256")
 *   **Gyro Rate Detection:** Comprehensive parsing of gyro sampling rates from various header formats (`gyroSampleRateHz`, `looptime`, `gyro_sync_denom`) with case-insensitive matching and proper division-based denominator calculation.
 *   **Mathematical Implementation:** 
     *   **PT1 (1st order)**: `H(s) = 1/(1 + s/ωc)` - Standard single-pole lowpass

--- a/Overview.md
+++ b/Overview.md
@@ -3,131 +3,138 @@
 The Rust program processes Betaflight Blackbox CSV logs to generate various plots. Here's a concise overview:
 
 **Configuration:**
+
 All analysis parameters, thresholds, plot dimensions, and algorithmic constants are centrally defined in `src/constants.rs`, making the implementation highly configurable for different analysis needs and flight controller characteristics.
 
 **Core Functionality:**
 
 1.  **Argument Parsing (`src/main.rs`):**
-    *   Parses command-line arguments: input CSV file(s), an optional `--dps` parameter (requires a numeric threshold value for detailed step response plots with low/high split), and an optional `--output-dir` for specifying the output directory.
-    *   Additional options include `--help` and `--version` for user assistance.
-    *   The `--output-dir` parameter now requires a directory path when specified. If omitted, plots are saved in the source folder (input file's directory).
-    *   Handles multiple input files and determines if a directory prefix should be added to output filenames to avoid collisions when processing files from different directories.
+    * Parses command-line arguments: input CSV file(s), an optional `--dps` parameter (requires a numeric threshold value for detailed step response plots with low/high split), and an optional `--output-dir` for specifying the output directory.
+    * Additional options include `--help` and `--version` for user assistance.
+    * The `--output-dir` parameter now requires a directory path when specified. If omitted, plots are saved in the source folder (input file's directory).
+    * Handles multiple input files and determines if a directory prefix should be added to output filenames to avoid collisions when processing files from different directories.
 
 2.  **File Processing (`src/main.rs:process_file`):**
-    *   For each input CSV:
-        *   **Path Setup:** Determines input and output paths.
-        *   **Data Parsing (`src/data_input/log_parser.rs:parse_log_file`):** Reads the CSV, extracts log data (time, gyro, setpoint, F-term, etc.), sample rate, and checks for the presence of essential data headers.
-        *   **Step Response Data Preparation:**
-            *   Filters log data, excluding the start and end seconds (constants `EXCLUDE_START_S`, `EXCLUDE_END_S` from `src/constants.rs`) to create contiguous segments of time, setpoint, and gyro data for each axis. This data is stored in `contiguous_sr_input_data`.
-        *   **Step Response Calculation (`src/data_analysis/calc_step_response.rs:calculate_step_response`):**
-            *   This is the core of the step response analysis. It implements **non-parametric system identification** using Wiener deconvolution rather than traditional first-order or second-order curve fitting. This approach directly extracts the system's actual step response without assuming a specific mathematical model, allowing it to capture complex, higher-order dynamics and non-linearities.
-            *   For each axis (Roll, Pitch, Yaw):
-                *   It takes the prepared time, setpoint, and (optionally smoothed via `INITIAL_GYRO_SMOOTHING_WINDOW`) gyro data arrays and the sample rate.
-                *   **Windowing:** The input signals (setpoint and gyro) are segmented into overlapping windows (`winstacker_contiguous`) of `FRAME_LENGTH_S` duration. A Tukey window (`tukeywin` with `TUKEY_ALPHA`) is applied to each segment to reduce spectral leakage.
-                *   **Movement Threshold:** Windows are discarded if the maximum absolute setpoint value within them is below `MOVEMENT_THRESHOLD_DEG_S`.
-                *   **Deconvolution:** For each valid window, Wiener deconvolution (`wiener_deconvolution_window`) is performed between the windowed setpoint (input) and gyro (output) signals in the frequency domain. This estimates the impulse response of the system. A regularization term (`0.0001`) helps stabilize the deconvolution.
-                *   **Impulse to Step Response:** The resulting impulse response is converted to a step response by cumulative summation (`cumulative_sum`). This step response is then truncated to `RESPONSE_LENGTH_S`.
-                *   **Y-Correction (Normalization):**
-                    *   If `APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION` is true, each individual step response window is normalized. The mean of its steady-state portion (defined by `STEADY_STATE_START_S` and `STEADY_STATE_END_S`) is calculated. If this mean is significant (abs > `Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS`), the entire response window is divided by this mean, aiming to make its steady-state value approach 1.0.
-                *   **Quality Control (QC):**
-                    *   Each (potentially Y-corrected) step response window undergoes QC. The minimum and maximum values of its steady-state portion are checked against `NORMALIZED_STEADY_STATE_MIN_VAL` and `NORMALIZED_STEADY_STATE_MAX_VAL`.
-                    *   Optionally (`ENABLE_NORMALIZED_STEADY_STATE_MEAN_CHECK`), the mean of the steady-state portion is also checked against `NORMALIZED_STEADY_STATE_MEAN_MIN` and `NORMALIZED_STEADY_STATE_MEAN_MAX`.
-                    *   Only windows passing QC are kept.
-                *   The function returns:
+    * For each input CSV:
+        * **Path Setup:** Determines input and output paths.
+        * **Data Parsing (`src/data_input/log_parser.rs:parse_log_file`):** Reads the CSV, extracts log data (time, gyro, setpoint, F-term, etc.), sample rate, and checks for the presence of essential data headers.
+        * **Step Response Data Preparation:**
+            * Filters log data, excluding the start and end seconds (constants `EXCLUDE_START_S`, `EXCLUDE_END_S` from `src/constants.rs`) to create contiguous segments of time, setpoint, and gyro data for each axis. This data is stored in `contiguous_sr_input_data`.
+        * **Step Response Calculation (`src/data_analysis/calc_step_response.rs:calculate_step_response`):**
+            * This is the core of the step response analysis. It implements **non-parametric system identification** using Wiener deconvolution rather than traditional first-order or second-order curve fitting. This approach directly extracts the system's actual step response without assuming a specific mathematical model, allowing it to capture complex, higher-order dynamics and non-linearities.
+            * For each axis (Roll, Pitch, Yaw):
+                * It takes the prepared time, setpoint, and (optionally smoothed via `INITIAL_GYRO_SMOOTHING_WINDOW`) gyro data arrays and the sample rate.
+                * **Windowing:** The input signals (setpoint and gyro) are segmented into overlapping windows (`winstacker_contiguous`) of `FRAME_LENGTH_S` duration. A Tukey window (`tukeywin` with `TUKEY_ALPHA`) is applied to each segment to reduce spectral leakage.
+                * **Movement Threshold:** Windows are discarded if the maximum absolute setpoint value within them is below `MOVEMENT_THRESHOLD_DEG_S`.
+                * **Deconvolution:** For each valid window, Wiener deconvolution (`wiener_deconvolution_window`) is performed between the windowed setpoint (input) and gyro (output) signals in the frequency domain. This estimates the impulse response of the system. A regularization term (`0.0001`) helps stabilize the deconvolution.
+                * **Impulse to Step Response:** The resulting impulse response is converted to a step response by cumulative summation (`cumulative_sum`). This step response is then truncated to `RESPONSE_LENGTH_S`.
+                * **Y-Correction (Normalization):**
+                    * If `APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION` is true, each individual step response window is normalized. The mean of its steady-state portion (defined by `STEADY_STATE_START_S` and `STEADY_STATE_END_S`) is calculated. If this mean is significant (abs > `Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS`), the entire response window is divided by this mean, aiming to make its steady-state value approach 1.0.
+                * **Quality Control (QC):**
+                    * Each (potentially Y-corrected) step response window undergoes QC. The minimum and maximum values of its steady-state portion are checked against `NORMALIZED_STEADY_STATE_MIN_VAL` and `NORMALIZED_STEADY_STATE_MAX_VAL`.
+                    * Optionally (`ENABLE_NORMALIZED_STEADY_STATE_MEAN_CHECK`), the mean of the steady-state portion is also checked against `NORMALIZED_STEADY_STATE_MEAN_MIN` and `NORMALIZED_STEADY_STATE_MEAN_MAX`.
+                    * Only windows passing QC are kept.
+                * The function returns:
                     1.  A time vector for the step response plot (`response_time`).
                     2.  A 2D array (`valid_stacked_responses`) containing all step response windows that passed QC.
                     3.  A 1D array (`valid_window_max_setpoints`) of the maximum setpoint values for each corresponding valid window.
-        *   **Plot Generation (various functions in `src/plot_functions/`):**
-            *   `plot_step_response` (in `src/plot_functions/plot_step_response.rs`): Takes the results from `calculate_step_response`.
-                *   Separates the QC'd responses into "low" and "high" setpoint groups based on the `setpoint_threshold` if the `--dps` parameter (and thus `show_legend`) is provided.
-                *   **Averaging & Final Normalization (`plot_functions::plot_step_response::process_response`):**
-                    *   The QC'd responses (either low, high, or combined) are averaged using `calc_step_response::average_responses`.
-                    *   The averaged response is smoothed using a moving average (`calc_step_response::moving_average_smooth_f64`) with `POST_AVERAGING_SMOOTHING_WINDOW`.
-                    *   The smoothed response is shifted to start at 0.0.
-                    *   A **final normalization** step is performed: the mean of the steady-state portion of this *averaged, smoothed, and shifted* response is calculated. The entire response is then divided by this mean to ensure the plotted average response aims for a steady-state of 1.0.
-                    *   The final response is only plotted if its steady-state mean (after this final normalization) is within `FINAL_NORMALIZED_STEADY_STATE_TOLERANCE` of 1.0.
-                *   Calculates peak value and delay time (Td) for each plotted average response using `calc_step_response::find_peak_value` and `calc_step_response::calculate_delay_time`.
-                    *   **Delay Time (Td) Calculation:** The delay time is calculated as the time for the step response to reach 50% of its final value. Linear interpolation is used for precise determination of the 50% threshold crossing. A fixed offset of -1ms is applied to the calculated time (in milliseconds) before converting to seconds, and the result is constrained to be non-negative.
-                *   Generates and saves the step response plot.
-            *   **Other plots generated (`src/plot_functions/`):**
-                *   `plot_pidsum_error_setpoint`: PIDsum (P+I+D), PID Error (Setpoint - GyroADC), and Setpoint time-domain traces for each axis.
-                *   `plot_setpoint_vs_gyro`: Setpoint and filtered gyro time-domain comparison for each axis.
-                *   `plot_gyro_vs_unfilt`: Filtered vs. unfiltered gyro time-domain comparison for each axis. Includes enhanced cross-correlation filtering delay calculation.
-                *   `plot_gyro_spectrums`: Frequency-domain amplitude spectrums of filtered and unfiltered gyro data with intelligent peak detection and labeling using scale-aware thresholds (`FILTERED_GYRO_MIN_THRESHOLD` for filtered gyro data). Includes enhanced cross-correlation filtering delay calculation and flight firmware filter response curve overlays.
-                *   `plot_psd`: Power Spectral Density plots in dB scale with peak labeling. Includes enhanced cross-correlation filtering delay calculation.
-                *   `plot_d_term_spectrums`: Frequency-domain amplitude spectrums of D-term data with intelligent peak detection using scale-aware thresholds (`FILTERED_D_TERM_MIN_THRESHOLD` for filtered D-term data). Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0).
-                *   `plot_d_term_psd`: Power Spectral Density plots of D-term data in dB scale with intelligent threshold filtering (`PSD_PEAK_LABEL_MIN_VALUE_DB` for filtered data) and enhanced formatting. Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0).
-                *   `plot_d_term_heatmap`: D-term throttle-frequency heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze D-term energy distribution across different throttle levels.
-                *   `plot_psd_db_heatmap`: Spectrograms showing PSD vs. time as heatmaps using Short-Time Fourier Transform (STFT) with configurable window duration and overlap.
-                *   `plot_throttle_freq_heatmap`: Heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze noise characteristics across different throttle levels.
+        * **Plot Generation (various functions in `src/plot_functions/`):**
+            * `plot_step_response` (in `src/plot_functions/plot_step_response.rs`): Takes the results from `calculate_step_response`.
+                * Separates the QC'd responses into "low" and "high" setpoint groups based on the `setpoint_threshold` if the `--dps` parameter (and thus `show_legend`) is provided.
+                * **Averaging & Final Normalization (`plot_functions::plot_step_response::process_response`):**
+                    * The QC'd responses (either low, high, or combined) are averaged using `calc_step_response::average_responses`.
+                    * The averaged response is smoothed using a moving average (`calc_step_response::moving_average_smooth_f64`) with `POST_AVERAGING_SMOOTHING_WINDOW`.
+                    * The smoothed response is shifted to start at 0.0.
+                    * A **final normalization** step is performed: the mean of the steady-state portion of this *averaged, smoothed, and shifted* response is calculated. The entire response is then divided by this mean to ensure the plotted average response aims for a steady-state of 1.0.
+                    * The final response is only plotted if its steady-state mean (after this final normalization) is within `FINAL_NORMALIZED_STEADY_STATE_TOLERANCE` of 1.0.
+                * Calculates peak value and delay time (Td) for each plotted average response using `calc_step_response::find_peak_value` and `calc_step_response::calculate_delay_time`.
+                    * **Delay Time (Td) Calculation:** The delay time is calculated as the time for the step response to reach 50% of its final value. Linear interpolation is used for precise determination of the 50% threshold crossing. A fixed offset of -1ms is applied to the calculated time (in milliseconds) before converting to seconds, and the result is constrained to be non-negative.
+                * Generates and saves the step response plot.
+            * **Other plots generated (`src/plot_functions/`):**
+                * `plot_pidsum_error_setpoint`: PIDsum (P+I+D), PID Error (Setpoint - GyroADC), and Setpoint time-domain traces for each axis.
+                * `plot_setpoint_vs_gyro`: Setpoint and filtered gyro time-domain comparison for each axis.
+                * `plot_gyro_vs_unfilt`: Filtered vs. unfiltered gyro time-domain comparison for each axis. Includes enhanced cross-correlation filtering delay calculation.
+                * `plot_gyro_spectrums`: Frequency-domain amplitude spectrums of filtered and unfiltered gyro data with intelligent peak detection and labeling using scale-aware thresholds (`FILTERED_GYRO_MIN_THRESHOLD` for filtered gyro data). Includes enhanced cross-correlation filtering delay calculation and flight firmware filter response curve overlays.
+                * `plot_psd`: Power Spectral Density plots in dB scale with peak labeling. Includes enhanced cross-correlation filtering delay calculation.
+                * `plot_d_term_spectrums`: Frequency-domain amplitude spectrums of D-term data with intelligent peak detection using scale-aware thresholds (`FILTERED_D_TERM_MIN_THRESHOLD` for filtered D-term data). Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0).
+                * `plot_d_term_psd`: Power Spectral Density plots of D-term data in dB scale with intelligent threshold filtering (`PSD_PEAK_LABEL_MIN_VALUE_DB` for filtered data) and enhanced formatting. Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0).
+                * `plot_d_term_heatmap`: D-term throttle-frequency heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze D-term energy distribution across different throttle levels.
+                * `plot_psd_db_heatmap`: Spectrograms showing PSD vs. time as heatmaps using Short-Time Fourier Transform (STFT) with configurable window duration and overlap.
+                * `plot_throttle_freq_heatmap`: Heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze noise characteristics across different throttle levels.
 
 **Filtering Delay Calculation (`src/data_analysis/filter_delay.rs`):**
 
+***
+
 ### Enhanced Cross-Correlation Method (Primary Implementation)
-*   **Algorithm:** For each axis (Roll, Pitch, Yaw), calculates normalized cross-correlation between filtered (`gyroADC`) and unfiltered (`gyroUnfilt`) gyro signals at different time delays using double-precision (f64) arithmetic throughout.
-*   **Delay Detection:** Identifies the delay that produces the highest correlation coefficient and converts from samples to milliseconds using the sample rate.
-*   **Subsample Precision:** Uses parabolic interpolation around the peak correlation to achieve subsample delay accuracy, addressing precision limitations of basic sample-rate resolution.
-*   **Quality Control:** Requires correlation coefficients above configurable thresholds (`MIN_CORRELATION_THRESHOLD`, `FALLBACK_CORRELATION_THRESHOLD`) with fallback mechanisms for challenging signal conditions.
-*   **Error Handling:** Provides detailed error reporting (`DelayCalculationError`) for insufficient data, low correlation, and signal mismatches.
-*   **Precision Consistency:** All correlation calculations use f64 precision throughout for maximum accuracy.
+
+* **Algorithm:** For each axis (Roll, Pitch, Yaw), calculates normalized cross-correlation between filtered (`gyroADC`) and unfiltered (`gyroUnfilt`) gyro signals at different time delays using double-precision (f64) arithmetic throughout.
+* **Delay Detection:** Identifies the delay that produces the highest correlation coefficient and converts from samples to milliseconds using the sample rate.
+* **Subsample Precision:** Uses parabolic interpolation around the peak correlation to achieve subsample delay accuracy, addressing precision limitations of basic sample-rate resolution.
+* **Quality Control:** Requires correlation coefficients above configurable thresholds (`MIN_CORRELATION_THRESHOLD`, `FALLBACK_CORRELATION_THRESHOLD`) with fallback mechanisms for challenging signal conditions.
+* **Error Handling:** Provides detailed error reporting (`DelayCalculationError`) for insufficient data, low correlation, and signal mismatches.
+* **Precision Consistency:** All correlation calculations use f64 precision throughout for maximum accuracy.
+
+***
 
 ### Implementation Details
-*   **Data Validation:** Performs comprehensive data availability diagnostics across all axes before analysis.
-*   **Averaging:** Individual axis delays are averaged to provide an overall system delay measurement when sufficient correlation is achieved.
-*   **Bounds Checking:** Comprehensive bounds checking with `saturating_sub()` and explicit runtime verification prevents array access violations. Limits maximum delay search range (`MAX_DELAY_FRACTION`, `MAX_DELAY_SAMPLES`) to prevent unrealistic results and ensures robust parabolic interpolation.
-*   **Confidence Value Clamping:** Confidence values are clamped to the valid range [0, 1] to handle numerical noise in correlation calculations that could cause values to slightly exceed 1.0.
-*   **Configurable Thresholds:** All correlation thresholds and delay search parameters are defined as named constants in `src/constants.rs` for maintainability and tuning.
-*   **Display:** Results are shown in console output with confidence metrics (as percentages), and estimates are integrated into plot legends as "Delay: X.Xms(c:XX%)" for `_GyroVsUnfilt_stacked.png`, `_Gyro_Spectrums_comparative.png`, and `_Gyro_PSD_comparative.png` outputs.
+
+* **Data Validation:** Performs comprehensive data availability diagnostics across all axes before analysis.
+* **Averaging:** Individual axis delays are averaged to provide an overall system delay measurement when sufficient correlation is achieved.
+* **Bounds Checking:** Comprehensive bounds checking with `saturating_sub()` and explicit runtime verification prevents array access violations. Limits maximum delay search range (`MAX_DELAY_FRACTION`, `MAX_DELAY_SAMPLES`) to prevent unrealistic results and ensures robust parabolic interpolation.
+* **Confidence Value Clamping:** Confidence values are clamped to the valid range \[0, 1] to handle numerical noise in correlation calculations that could cause values to slightly exceed 1.0.
+* **Configurable Thresholds:** All correlation thresholds and delay search parameters are defined as named constants in `src/constants.rs` for maintainability and tuning.
+* **Display:** Results are shown in console output with confidence metrics (as percentages), and estimates are integrated into plot legends as "Delay: X.Xms(c:XX%)" for `_GyroVsUnfilt_stacked.png`, `_Gyro_Spectrums_comparative.png`, and `_Gyro_PSD_comparative.png` outputs.
 
 **Filter Response Curves (`src/data_analysis/filter_response.rs`):**
 
-*   **Flight Firmware Integration:** Automatically detects and parses filter configurations from Betaflight, EmuFlight, and INAV blackbox headers including filter types (PT1, PT2, PT3, PT4, BIQUAD), cutoff frequencies, and dynamic filter ranges.
-*   **Butterworth Correction Visualization (Optional):** When enabled with the `--butterworth` command-line parameter, displays per-stage PT1 implementation details for PT2/PT3/PT4 filters on gyro and D-term spectrum plots:
-    *   PT2/PT3/PT4 filters are implemented as cascaded PT1 stages with Butterworth correction factors (PT2: 1.554×, PT3: 1.961×, PT4: 2.299×)
-    *   Main curves (colored) show user-configured filter response (e.g., "LPF1 (PT2 @ 90Hz)")
-    *   Per-stage curves (gray, prefixed with ≈) show actual PT1 implementation (e.g., "≈ LPF1 (Two PT1 @ 140Hz per-stage)")
-    *   Vertical cutoff lines: solid for configured cutoff, dotted for per-stage cutoff
-    *   Formula: per-stage cutoff = configured cutoff × correction factor
-    *   Applies to all firmware (Betaflight, EmuFlight, INAV) using PT2/PT3/PT4 filters
-    *   IMUF configurations include version information when available (e.g., "IMUF v256")
-*   **Gyro Rate Detection:** Comprehensive parsing of gyro sampling rates from various header formats (`gyroSampleRateHz`, `looptime`, `gyro_sync_denom`) with case-insensitive matching and proper division-based denominator calculation.
-*   **Mathematical Implementation:** 
-    *   **PT1 (1st order)**: `H(s) = 1/(1 + s/ωc)` - Standard single-pole lowpass
-    *   **PT2 (2nd order)**: `H(s) = 1/(1 + √2·s/ωc + (s/ωc)²)` - Butterworth response yielding -3dB at cutoff  
-    *   **PT3 (3rd order)**: `|H(jω)| = 1/sqrt(1 + (ω/ωc)⁶)` - Simplified 3rd order approximation maintaining -3dB at cutoff
-    *   **PT4 (4th order)**: `|H(jω)| = 1/sqrt(1 + (ω/ωc)⁸)` - Simplified 4th order approximation maintaining -3dB at cutoff
-    *   **BIQUAD (2nd order)**: Currently implemented as PT2 Butterworth response (Q=0.707). Ready for Q-factor enhancement with `H(s) = ω₀²/(s² + (ω₀/Q)·s + ω₀²)` where ω₀ = 2π·fc
-    *   Note: ωc represents angular cutoff frequency (ωc = 2π·fc where fc is cutoff in Hz)
-*   **Curve Generation:** Logarithmic frequency spacing from 10% of cutoff frequency to gyro Nyquist frequency (gyro_rate/2) with 1000 points for smooth visualization. Includes division-by-zero protection and edge case handling.
-*   **Visualization Integration:** Filter response curves are overlaid on spectrum plots (`plot_gyro_spectrums`) as red curves with clear legends showing filter type and cutoff frequency, enhancing spectrum analysis with theoretical filter characteristics.
-*   **Quality Assurance:** Comprehensive unit tests verify -3dB magnitude response at cutoff frequencies for all filter types and validate gyro rate extraction accuracy.
+* **Flight Firmware Integration:** Automatically detects and parses filter configurations from Betaflight, EmuFlight, and INAV blackbox headers including filter types (PT1, PT2, PT3, PT4, BIQUAD), cutoff frequencies, and dynamic filter ranges.
+* **Butterworth Correction Visualization (Optional):** When enabled with the `--butterworth` command-line parameter, displays per-stage PT1 implementation details for PT2/PT3/PT4 filters on gyro and D-term spectrum plots:
+    * PT2/PT3/PT4 filters are implemented as cascaded PT1 stages with Butterworth correction factors (PT2: 1.554×, PT3: 1.961×, PT4: 2.299×)
+    * Main curves (colored) show user-configured filter response (e.g., "LPF1 (PT2 @ 90Hz)")
+    * Per-stage curves (gray, prefixed with ≈) show actual PT1 implementation (e.g., "≈ LPF1 (Two PT1 @ 140Hz per-stage)")
+    * Vertical cutoff lines: solid for configured cutoff, dotted for per-stage cutoff
+    * Formula: per-stage cutoff = configured cutoff × correction factor
+    * Applies to all firmware (Betaflight, EmuFlight, INAV) using PT2/PT3/PT4 filters
+    * IMUF configurations include version information when available (e.g., "IMUF v256")
+* **Gyro Rate Detection:** Comprehensive parsing of gyro sampling rates from various header formats (`gyroSampleRateHz`, `looptime`, `gyro_sync_denom`) with case-insensitive matching and proper division-based denominator calculation.
+* **Mathematical Implementation:**
+    * **PT1 (1st order)**: $H(s) = 1/(1 + s/\omega_c)$ - Standard single-pole lowpass
+    * **PT2 (2nd order)**: $H(s) = 1/(1 + \sqrt{2}\cdot s/\omega_c + (s/\omega_c)^2)$ - Butterworth response yielding -3dB at cutoff
+    * **PT3 (3rd order)**: $|H(j\omega)| = 1/\sqrt{1 + (\omega/\omega_c)^6}$ - Simplified 3rd order approximation maintaining -3dB at cutoff
+    * **PT4 (4th order)**: $|H(j\omega)| = 1/\sqrt{1 + (\omega/\omega_c)^8}$ - Simplified 4th order approximation maintaining -3dB at cutoff
+    * **BIQUAD (2nd order)**: Currently implemented as PT2 Butterworth response (Q=0.707). Ready for Q-factor enhancement with $H(s) = \omega_0^2/(s^2 + (\omega_0/Q)\cdot s + \omega_0^2)$ where $\omega_0 = 2\pi\cdot f_c$
+    * Note: $\omega_c$ represents angular cutoff frequency ($\omega_c = 2\pi\cdot f_c$ where $f_c$ is cutoff in Hz)
+* **Curve Generation:** Logarithmic frequency spacing from 10% of cutoff frequency to gyro Nyquist frequency (gyro\_rate/2) with 1000 points for smooth visualization. Includes division-by-zero protection and edge case handling.
+* **Visualization Integration:** Filter response curves are overlaid on spectrum plots (`plot_gyro_spectrums`) as red curves with clear legends showing filter type and cutoff frequency, enhancing spectrum analysis with theoretical filter characteristics.
+* **Quality Assurance:** Comprehensive unit tests verify -3dB magnitude response at cutoff frequencies for all filter types and validate gyro rate extraction accuracy.
 
 **Step-Response Comparison with Other Analysis Tools:**
 
 This implementation provides detailed and configurable analysis of flight controller performance. The modular design and centralized configuration system make it adaptable for various analysis requirements.
 
-*   **Compared to PIDtoolbox/Matlab (`PTstepcalc.m`):**
-    *   **Deconvolution Method:** Both use Wiener deconvolution with a regularization term.
-    *   **Windowing:** This implementation uses Tukey (`TUKEY_ALPHA`) on input/output before FFT; Matlab uses Hann.
-    *   **Smoothing:** This implementation has optional initial gyro smoothing (`INITIAL_GYRO_SMOOTHING_WINDOW`) and mandatory post-average smoothing (`POST_AVERAGING_SMOOTHING_WINDOW`). Matlab smooths raw gyro input upfront.
-    *   **Normalization/Y-Correction:**
-        *   This implementation: Optional individual response Y-correction (normalize by own steady-state mean, `APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION`, `Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS`) followed by final normalization of the averaged response to target 1.0 (within `FINAL_NORMALIZED_STEADY_STATE_TOLERANCE`).
-        *   Matlab: Optional Y-correction on individual responses by calculating an offset to make the mean 1.0.
-    *   **Quality Control (QC):** Both apply QC to individual responses based on steady-state characteristics. This implementation uses `NORMALIZED_STEADY_STATE_MIN_VAL`, `NORMALIZED_STEADY_STATE_MAX_VAL`, and optionally `NORMALIZED_STEADY_STATE_MEAN_MIN`, `NORMALIZED_STEADY_STATE_MEAN_MAX`. Matlab uses `min(steadyStateResp) > 0.5 && max(steadyStateResp) < 3`.
-    *   **Output:** This implementation can plot low/high/combined responses based on `setpoint_threshold` if `--dps` is provided with a value. Matlab stacks all valid responses.
+* **Compared to PIDtoolbox/Matlab (`PTstepcalc.m`):**
+    * **Deconvolution Method:** Both use Wiener deconvolution with a regularization term.
+    * **Windowing:** This implementation uses Tukey (`TUKEY_ALPHA`) on input/output before FFT; Matlab uses Hann.
+    * **Smoothing:** This implementation has optional initial gyro smoothing (`INITIAL_GYRO_SMOOTHING_WINDOW`) and mandatory post-average smoothing (`POST_AVERAGING_SMOOTHING_WINDOW`). Matlab smooths raw gyro input upfront.
+    * **Normalization/Y-Correction:**
+        * This implementation: Optional individual response Y-correction (normalize by own steady-state mean, `APPLY_INDIVIDUAL_RESPONSE_Y_CORRECTION`, `Y_CORRECTION_MIN_UNNORMALIZED_MEAN_ABS`) followed by final normalization of the averaged response to target 1.0 (within `FINAL_NORMALIZED_STEADY_STATE_TOLERANCE`).
+        * Matlab: Optional Y-correction on individual responses by calculating an offset to make the mean 1.0.
+    * **Quality Control (QC):** Both apply QC to individual responses based on steady-state characteristics. This implementation uses `NORMALIZED_STEADY_STATE_MIN_VAL`, `NORMALIZED_STEADY_STATE_MAX_VAL`, and optionally `NORMALIZED_STEADY_STATE_MEAN_MIN`, `NORMALIZED_STEADY_STATE_MEAN_MAX`. Matlab uses `min(steadyStateResp) > 0.5 && max(steadyStateResp) < 3`.
+    * **Output:** This implementation can plot low/high/combined responses based on `setpoint_threshold` if `--dps` is provided with a value. Matlab stacks all valid responses.
 
-*   **Compared to PlasmaTree/Python (`PID-Analyzer.py`):**
-    *   **Deconvolution Method:** PlasmaTree also uses Wiener deconvolution with a signal-to-noise ratio (`sn`) term in the denominator, derived from a `cutfreq` parameter and smoothed, effectively acting as frequency-dependent regularization. This implementation uses a simpler constant regularization term (`0.0001`).
-    *   **Windowing:** PlasmaTree uses a Hanning window by default (or Tukey) applied to input and output segments before deconvolution. This implementation uses a Tukey window.
-    *   **Input for Deconvolution:** PlasmaTree calculates an `input` signal by reconstructing the setpoint as seen by the PID loop. This implementation directly uses the logged setpoint values.
-    *   **Smoothing:** PlasmaTree does not include initial gyro smoothing like this implementation's `INITIAL_GYRO_SMOOTHING_WINDOW`. For the final averaged response, PlasmaTree uses a 2D histogram and Gaussian smoothing to find the "mode" response, different from this implementation's direct moving average on the time-domain averaged response.
-    *   **Normalization/Y-Correction:**
-        *   This implementation: Individual responses can be normalized to their steady-state mean, followed by final normalization of the averaged response.
-        *   PlasmaTree: Uses `weighted_mode_avr` to find the most common trace shape from response collections, which inherently handles variations without explicit Y-correction.
-    *   **Quality Control (QC):** PlasmaTree has a `resp_quality` metric based on deviation from initial average and uses a `toolow_mask` for low input responses. This implementation uses direct steady-state value checks.
-    *   **Averaging:**
-        *   This implementation: `average_responses` performs weighted average of QC'd responses.
-        *   PlasmaTree: `weighted_mode_avr` uses 2D histogram analysis to determine representative traces.
-    *   **Output:** Both can plot low and high input responses based on configurable thresholds.
+* **Compared to PlasmaTree/Python (`PID-Analyzer.py`):**
+    * **Deconvolution Method:** PlasmaTree also uses Wiener deconvolution with a signal-to-noise ratio (`sn`) term in the denominator, derived from a `cutfreq` parameter and smoothed, effectively acting as frequency-dependent regularization. This implementation uses a simpler constant regularization term (`0.0001`).
+    * **Windowing:** PlasmaTree uses a Hanning window by default (or Tukey) applied to input and output segments before deconvolution. This implementation uses a Tukey window.
+    * **Input for Deconvolution:** PlasmaTree calculates an `input` signal by reconstructing the setpoint as seen by the PID loop. This implementation directly uses the logged setpoint values.
+    * **Smoothing:** PlasmaTree does not include initial gyro smoothing like this implementation's `INITIAL_GYRO_SMOOTHING_WINDOW`. For the final averaged response, PlasmaTree uses a 2D histogram and Gaussian smoothing to find the "mode" response, different from this implementation's direct moving average on the time-domain averaged response.
+    * **Normalization/Y-Correction:**
+        * This implementation: Individual responses can be normalized to their steady-state mean, followed by final normalization of the averaged response.
+        * PlasmaTree: Uses `weighted_mode_avr` to find the most common trace shape from response collections, which inherently handles variations without explicit Y-correction.
+    * **Quality Control (QC):** PlasmaTree has a `resp_quality` metric based on deviation from initial average and uses a `toolow_mask` for low input responses. This implementation uses direct steady-state value checks.
+    * **Averaging:**
+        * This implementation: `average_responses` performs weighted average of QC'd responses.
+        * PlasmaTree: `weighted_mode_avr` uses 2D histogram analysis to determine representative traces.
+    * **Output:** Both can plot low and high input responses based on configurable thresholds.
 
 This Rust implementation offers a comprehensive and configurable analysis pipeline for flight controller performance evaluation with sophisticated signal processing techniques and detailed visualization capabilities.

--- a/Readme.md
+++ b/Readme.md
@@ -13,13 +13,16 @@ cargo build --release
 
 ### Usage
 ```shell
-Usage: ./BlackBox_CSV_Render <input_file1.csv> [<input_file2.csv> ...] [--dps <value>] [--output-dir <directory>]
+Usage: ./BlackBox_CSV_Render <input_file1.csv> [<input_file2.csv> ...] [--dps <value>] [--output-dir <directory>] [--butterworth] [--debug]
   <input_fileX.csv>: Path to one or more input CSV log files (required).
   --dps <value>: Optional. Enables detailed step response plots with the specified
                  deg/s threshold value. Must be a positive number.
                  If --dps is omitted, a general step-response is shown.
   --output-dir <directory>: Optional. Specifies the output directory for generated plots.
                          If omitted, plots are saved in the source folder (input file's directory).
+  --butterworth: Optional. Show Butterworth per-stage PT1 cutoffs for PT2/PT3/PT4 filters
+                 as gray curves/lines on gyro and D-term spectrum plots.
+  --debug: Optional. Shows detailed metadata information during processing.
 
 Arguments can be in any order. Wildcards (e.g., *.csv) are supported by the shell.
 ```
@@ -28,10 +31,10 @@ Arguments can be in any order. Wildcards (e.g., *.csv) are supported by the shel
 ./target/release/BlackBox_CSV_Render path/to/BTFL_Log.csv
 ```
 ```shell
-./target/release/BlackBox_CSV_Render path/to/*LOG*.csv --dps 500
+./target/release/BlackBox_CSV_Render path/to/*LOG*.csv --dps 500 --butterworth
 ```
 ```shell
-./target/release/BlackBox_CSV_Render path1/to/BTFL_*.csv path2/to/EMUF_*.csv --dps 360 --output-dir ./plots
+./target/release/BlackBox_CSV_Render path1/to/BTFL_*.csv path2/to/EMUF_*.csv --dps 360 --output-dir ./plots --butterworth
 ```
 
 ### Output

--- a/src/data_analysis/filter_response.rs
+++ b/src/data_analysis/filter_response.rs
@@ -57,16 +57,17 @@ pub struct DynamicFilterConfig {
     pub enabled: bool,
 }
 
-/// IMUF filter configuration for HELIOSPRING flight controllers
+/// IMUF filter configuration with Butterworth correction (Betaflight/EmuFlight)
 #[derive(Debug, Clone)]
 pub struct ImufFilterConfig {
     // Header values (as configured)
-    pub lowpass_cutoff_hz: f64, // Original configured cutoff from header
+    pub lowpass_cutoff_hz: f64, // Configured combined cutoff from header (effective -3dB point)
     pub ptn_order: u32,         // Filter order (1-4 -> PT1, PT2, PT3, PT4)
     pub q_factor: f64,          // Q-factor (scaled by 1000 in headers)
+    pub revision: Option<u32>,  // IMUF revision from header (e.g., 256, 257)
 
-    // Calculated values (accounting for IMU-F implementation)
-    pub effective_cutoff_hz: f64, // Cutoff after PTN scaling factors
+    // Calculated values (Butterworth correction for cascaded stages)
+    pub effective_cutoff_hz: f64, // Per-stage PT1 cutoff (scaled up to achieve configured combined response)
 
     pub enabled: bool,
 }
@@ -88,6 +89,72 @@ pub struct AllFilterConfigs {
 
 /// Type alias for filter curve data: (label, curve_points, cutoff_hz)
 pub type FilterCurveData = (String, Vec<(f64, f64)>, f64);
+
+/// Helper function to add PTn filter curves with Butterworth correction
+/// Generates both the user-configured curve and the per-stage implementation curve
+fn add_ptn_filter_curves(
+    filter_curves: &mut Vec<FilterCurveData>,
+    filter_type: FilterType,
+    cutoff_hz: f64,
+    label_prefix: &str,
+    max_frequency_hz: f64,
+    num_points: usize,
+    show_butterworth: bool,
+) {
+    // Generate curve for user-configured cutoff (e.g., PT2 @ 90Hz)
+    let main_filter = FilterConfig {
+        filter_type,
+        cutoff_hz,
+        enabled: true,
+    };
+    let main_curve = generate_single_filter_curve(&main_filter, max_frequency_hz, num_points);
+    let main_label = format!(
+        "{} ({} @ {:.0}Hz)",
+        label_prefix,
+        filter_type.name(),
+        cutoff_hz
+    );
+    filter_curves.push((main_label, main_curve, cutoff_hz));
+
+    // Generate per-stage curve for PT2/PT3/PT4 (Butterworth correction) only if --butterworth flag is set
+    if !show_butterworth {
+        return;
+    }
+
+    let ptn_order = match filter_type {
+        FilterType::PT2 => 2,
+        FilterType::PT3 => 3,
+        FilterType::PT4 => 4,
+        _ => 0, // PT1 and BIQUAD don't need per-stage curves
+    };
+
+    if ptn_order > 1 {
+        let per_stage_cutoff = calculate_ptn_per_stage_cutoff(cutoff_hz, ptn_order);
+
+        // Only show per-stage if it's meaningfully different (> 1 Hz)
+        if (per_stage_cutoff - cutoff_hz).abs() > 1.0 {
+            let stage_count_text = match ptn_order {
+                2 => "Two PT1",
+                3 => "Three PT1",
+                4 => "Four PT1",
+                _ => "PT1",
+            };
+
+            let stage_filter = FilterConfig {
+                filter_type,
+                cutoff_hz: per_stage_cutoff,
+                enabled: true,
+            };
+            let stage_curve =
+                generate_single_filter_curve(&stage_filter, max_frequency_hz, num_points);
+            let stage_label = format!(
+                "≈ {} ({} @ {:.0}Hz per-stage)",
+                label_prefix, stage_count_text, per_stage_cutoff
+            );
+            filter_curves.push((stage_label, stage_curve, per_stage_cutoff));
+        }
+    }
+}
 
 /// Calculate frequency response magnitude for PT1 filter
 /// H(s) = 1 / (1 + s/ωc) where ωc = 2π * cutoff_hz
@@ -159,6 +226,7 @@ pub fn generate_individual_filter_curves(
     axis_config: &AxisFilterConfig,
     max_frequency_hz: f64,
     num_points: usize,
+    show_butterworth: bool,
 ) -> Vec<FilterCurveData> {
     let mut filter_curves = Vec::new();
 
@@ -166,51 +234,55 @@ pub fn generate_individual_filter_curves(
     if let Some(ref dyn_lpf1) = axis_config.dynamic_lpf1 {
         // Dynamic LPF1 takes precedence
         if dyn_lpf1.enabled && dyn_lpf1.min_cutoff_hz > 0.0 {
-            let static_filter = FilterConfig {
-                filter_type: dyn_lpf1.filter_type,
-                cutoff_hz: dyn_lpf1.min_cutoff_hz, // Use minimum cutoff
-                enabled: true,
-            };
-            let curve = generate_single_filter_curve(&static_filter, max_frequency_hz, num_points);
-            let label = if dyn_lpf1.max_cutoff_hz > dyn_lpf1.min_cutoff_hz {
+            let label_prefix = if dyn_lpf1.max_cutoff_hz > dyn_lpf1.min_cutoff_hz {
                 format!(
-                    "Dyn LPF1 ({} {:.0}-{:.0}Hz)",
-                    dyn_lpf1.filter_type.name(),
-                    dyn_lpf1.min_cutoff_hz,
-                    dyn_lpf1.max_cutoff_hz
+                    "Dyn LPF1 {:.0}-{:.0}Hz",
+                    dyn_lpf1.min_cutoff_hz, dyn_lpf1.max_cutoff_hz
                 )
             } else {
-                format!(
-                    "Dyn LPF1 ({} @ {:.0}Hz)",
-                    dyn_lpf1.filter_type.name(),
-                    dyn_lpf1.min_cutoff_hz
-                )
+                "Dyn LPF1".to_string()
             };
-            filter_curves.push((label, curve, dyn_lpf1.min_cutoff_hz));
+
+            // Use helper to add both main and per-stage curves for PTn filters
+            add_ptn_filter_curves(
+                &mut filter_curves,
+                dyn_lpf1.filter_type,
+                dyn_lpf1.min_cutoff_hz,
+                &label_prefix,
+                max_frequency_hz,
+                num_points,
+                show_butterworth,
+            );
         }
     } else if let Some(ref lpf1) = axis_config.lpf1 {
         // Static LPF1 fallback
         if lpf1.enabled && lpf1.cutoff_hz > 0.0 {
-            let curve = generate_single_filter_curve(lpf1, max_frequency_hz, num_points);
-            let label = format!(
-                "LPF1 ({} @ {:.0}Hz)",
-                lpf1.filter_type.name(),
-                lpf1.cutoff_hz
+            // Use helper to add both main and per-stage curves for PTn filters
+            add_ptn_filter_curves(
+                &mut filter_curves,
+                lpf1.filter_type,
+                lpf1.cutoff_hz,
+                "LPF1",
+                max_frequency_hz,
+                num_points,
+                show_butterworth,
             );
-            filter_curves.push((label, curve, lpf1.cutoff_hz));
         }
     }
 
     // Generate curve for LPF2 if enabled (always after LPF1)
     if let Some(ref lpf2) = axis_config.lpf2 {
         if lpf2.enabled && lpf2.cutoff_hz > 0.0 {
-            let curve = generate_single_filter_curve(lpf2, max_frequency_hz, num_points);
-            let label = format!(
-                "LPF2 ({} @ {:.0}Hz)",
-                lpf2.filter_type.name(),
-                lpf2.cutoff_hz
+            // Use helper to add both main and per-stage curves for PTn filters
+            add_ptn_filter_curves(
+                &mut filter_curves,
+                lpf2.filter_type,
+                lpf2.cutoff_hz,
+                "LPF2",
+                max_frequency_hz,
+                num_points,
+                show_butterworth,
             );
-            filter_curves.push((label, curve, lpf2.cutoff_hz));
         }
     }
 
@@ -225,7 +297,23 @@ pub fn generate_individual_filter_curves(
                 _ => FilterType::PT2, // Default fallback
             };
 
-            // Generate curve for header-configured cutoff (what user intended)
+            // Helper to get stage count text for per-stage labels
+            let stage_count_text = match imuf.ptn_order {
+                1 => "One PT1",
+                2 => "Two PT1",
+                3 => "Three PT1",
+                4 => "Four PT1",
+                _ => "Two PT1",
+            };
+
+            // Build version string
+            let version_str = if let Some(rev) = imuf.revision {
+                format!("IMUF v{}", rev)
+            } else {
+                "IMUF".to_string()
+            };
+
+            // Generate curve for header-configured cutoff (user sees PT2 @ 90Hz)
             let header_filter = FilterConfig {
                 filter_type,
                 cutoff_hz: imuf.lowpass_cutoff_hz,
@@ -234,27 +322,27 @@ pub fn generate_individual_filter_curves(
             let header_curve =
                 generate_single_filter_curve(&header_filter, max_frequency_hz, num_points);
             let header_label = format!(
-                "IMUF v256 Header ({} @ {:.0}Hz)",
+                "{} ({} @ {:.0}Hz)",
+                version_str,
                 filter_type.name(),
                 imuf.lowpass_cutoff_hz
             );
             filter_curves.push((header_label, header_curve, imuf.lowpass_cutoff_hz));
 
-            // Generate curve for effective cutoff (accounting for PTN scaling)
-            if (imuf.effective_cutoff_hz - imuf.lowpass_cutoff_hz).abs() > 1.0 {
-                let effective_filter = FilterConfig {
+            // Generate curve for per-stage PT1 cutoff (Butterworth correction - shows Two PT1 @ 140Hz) only if --butterworth flag is set
+            if show_butterworth && (imuf.effective_cutoff_hz - imuf.lowpass_cutoff_hz).abs() > 1.0 {
+                let stage_filter = FilterConfig {
                     filter_type,
                     cutoff_hz: imuf.effective_cutoff_hz,
                     enabled: true,
                 };
-                let effective_curve =
-                    generate_single_filter_curve(&effective_filter, max_frequency_hz, num_points);
-                let effective_label = format!(
-                    "IMUF v256 Effective ({} @ {:.0}Hz, PTN scaled)",
-                    filter_type.name(),
-                    imuf.effective_cutoff_hz
+                let stage_curve =
+                    generate_single_filter_curve(&stage_filter, max_frequency_hz, num_points);
+                let stage_label = format!(
+                    "≈ {} ({} @ {:.0}Hz per-stage)",
+                    version_str, stage_count_text, imuf.effective_cutoff_hz
                 );
-                filter_curves.push((effective_label, effective_curve, imuf.effective_cutoff_hz));
+                filter_curves.push((stage_label, stage_curve, imuf.effective_cutoff_hz));
             }
         }
     }
@@ -644,15 +732,21 @@ fn parse_dynamic_cutoffs(cutoff_str: &str) -> (f64, f64) {
     }
 }
 
-/// Calculate effective IMUF filter cutoff frequency accounting for PTN scaling factors
+/// Calculate per-stage PT1 cutoff frequency for IMUF filters
+/// Uses Butterworth correction factors to achieve proper combined response
 /// Based on IMU-F ptnFilter.c: Adj_f_cut = (float)f_cut * ScaleF[filter->order - 1]
-fn calculate_imuf_effective_cutoff(configured_cutoff_hz: f64, ptn_order: u32) -> f64 {
-    // PTN filter scaling factors from IMU-F source code
+///
+/// Example: For PT2 at 90 Hz combined:
+/// - Each PT1 stage runs at 90 * 1.554 = 140 Hz
+/// - Two stages at 140 Hz produce -3dB at 90 Hz combined
+fn calculate_ptn_per_stage_cutoff(configured_cutoff_hz: f64, ptn_order: u32) -> f64 {
+    // PTn cutoff correction factors from Betaflight/EmuFlight source
+    // Formula: 1 / sqrt(2^(1/n) - 1) where n is the filter order
     const PTN_SCALE_FACTORS: [f64; 4] = [
-        1.0,         // PT1 (order 1)
-        1.553773974, // PT2 (order 2)
-        1.961459177, // PT3 (order 3)
-        2.298959223, // PT4 (order 4)
+        1.0,         // PT1 (order 1) - no correction needed
+        1.553773974, // PT2 (order 2) - CUTOFF_CORRECTION_PT2
+        1.961459177, // PT3 (order 3) - CUTOFF_CORRECTION_PT3
+        2.298959223, // PT4 (order 4) - CUTOFF_CORRECTION_PT4
     ];
 
     let scale_factor = match ptn_order {
@@ -674,6 +768,11 @@ pub fn parse_imuf_filters_with_gyro_rate(
         .collect();
 
     let mut config = AllFilterConfigs::default();
+
+    // Parse IMUF revision (applies to all axes)
+    let imuf_revision = header_map
+        .get("imuf_revision")
+        .and_then(|s| s.parse::<u32>().ok());
 
     // Parse IMUF parameters for each axis
     let axis_names = ["roll", "pitch", "yaw"];
@@ -701,13 +800,14 @@ pub fn parse_imuf_filters_with_gyro_rate(
 
         // Create IMUF filter config if we have valid parameters
         if lowpass_cutoff_hz > 0.0 {
-            // Calculate effective cutoff after PTN scaling
-            let effective_cutoff_hz = calculate_imuf_effective_cutoff(lowpass_cutoff_hz, ptn_order);
+            // Calculate per-stage PT1 cutoff (Butterworth correction)
+            let effective_cutoff_hz = calculate_ptn_per_stage_cutoff(lowpass_cutoff_hz, ptn_order);
 
             config.gyro[axis_idx].imuf = Some(ImufFilterConfig {
                 lowpass_cutoff_hz,
                 ptn_order,
                 q_factor,
+                revision: imuf_revision,
                 effective_cutoff_hz,
                 enabled: true,
             });
@@ -725,11 +825,12 @@ pub fn parse_filter_config(headers: &[(String, String)]) -> AllFilterConfigs {
         .map(|(k, v)| (k.trim().to_lowercase(), v.trim().to_string()))
         .collect();
 
-    // Check for IMUF patterns (EmuFlight HELIOSPRING)
+    // Check for IMUF patterns (Betaflight/EmuFlight with PTn Butterworth correction)
     let has_imuf_pattern = header_map.contains_key("imuf_lowpass_roll")
         || header_map.contains_key("imuf_lowpass_pitch")
         || header_map.contains_key("imuf_lowpass_yaw")
-        || header_map.contains_key("imuf_ptn_order");
+        || header_map.contains_key("imuf_ptn_order")
+        || header_map.contains_key("imuf_revision");
 
     // Check for EmuFlight per-axis patterns
     let has_emuflight_pattern = header_map.contains_key("dterm_lowpass_hz_roll")
@@ -752,7 +853,7 @@ pub fn parse_filter_config(headers: &[(String, String)]) -> AllFilterConfigs {
 
     // Check for IMUF configuration and merge it with existing config
     if has_imuf_pattern {
-        println!("Detected EmuFlight HELIOSPRING IMUF v256 filter configuration");
+        println!("Detected PTn filters with Butterworth correction (IMUF)");
 
         // Extract gyro rate for sample rate correction calculations
         let gyro_rate_hz = extract_gyro_rate(Some(headers));
@@ -792,26 +893,37 @@ pub fn parse_filter_config(headers: &[(String, String)]) -> AllFilterConfigs {
             );
         }
         if let Some(ref imuf) = config.gyro[axis_idx].imuf {
-            let filter_type = match imuf.ptn_order {
-                1 => "PT1",
-                2 => "PT2",
-                3 => "PT3",
-                4 => "PT4",
-                _ => "PT2",
+            let stage_count_text = match imuf.ptn_order {
+                1 => "One PT1",
+                2 => "Two PT1",
+                3 => "Three PT1",
+                4 => "Four PT1",
+                _ => "Two PT1",
             };
+
+            let version_str = if let Some(rev) = imuf.revision {
+                format!("IMUF v{}", rev)
+            } else {
+                "IMUF".to_string()
+            };
+
             println!(
-                "    IMUF v256: {} Header={:.0}Hz → Effective={:.0}Hz (Q={:.1})",
-                filter_type, imuf.lowpass_cutoff_hz, imuf.effective_cutoff_hz, imuf.q_factor
+                "    {}: {} Combined={:.0}Hz → per-stage={:.0}Hz (Q={:.1})",
+                version_str,
+                stage_count_text,
+                imuf.lowpass_cutoff_hz,
+                imuf.effective_cutoff_hz,
+                imuf.q_factor
             );
 
-            // Show warnings for significant differences
+            // Show info about Butterworth correction
             let ptn_scaling_diff = imuf.effective_cutoff_hz - imuf.lowpass_cutoff_hz;
 
             if ptn_scaling_diff.abs() > 5.0 {
                 println!(
-                    "      WARNING: PTN scaling increases cutoff by {:.0}Hz ({:.1}x multiplier)",
-                    ptn_scaling_diff,
-                    imuf.effective_cutoff_hz / imuf.lowpass_cutoff_hz
+                    "      Note: Butterworth correction requires PT1 stages at {:.0}Hz to achieve {:.0}Hz combined response",
+                    imuf.effective_cutoff_hz,
+                    imuf.lowpass_cutoff_hz
                 );
             }
         }
@@ -942,12 +1054,12 @@ mod tests {
     }
 
     #[test]
-    fn test_imuf_calculation_functions() {
+    fn test_ptn_calculation_functions() {
         // Test PTN scaling factors
-        assert_eq!(calculate_imuf_effective_cutoff(100.0, 1), 100.0); // PT1 no scaling
-        assert!((calculate_imuf_effective_cutoff(100.0, 2) - 155.377).abs() < 0.1); // PT2 scaling
-        assert!((calculate_imuf_effective_cutoff(100.0, 3) - 196.146).abs() < 0.1); // PT3 scaling
-        assert!((calculate_imuf_effective_cutoff(100.0, 4) - 229.896).abs() < 0.1);
+        assert_eq!(calculate_ptn_per_stage_cutoff(100.0, 1), 100.0); // PT1 no scaling
+        assert!((calculate_ptn_per_stage_cutoff(100.0, 2) - 155.377).abs() < 0.1); // PT2 scaling
+        assert!((calculate_ptn_per_stage_cutoff(100.0, 3) - 196.146).abs() < 0.1); // PT3 scaling
+        assert!((calculate_ptn_per_stage_cutoff(100.0, 4) - 229.896).abs() < 0.1);
         // PT4 scaling
     }
 
@@ -957,7 +1069,8 @@ mod tests {
             lowpass_cutoff_hz: 100.0,
             ptn_order: 2,
             q_factor: 8.0,
-            effective_cutoff_hz: 155.4, // 100 * 1.553773974
+            revision: Some(256),
+            effective_cutoff_hz: 155.4, // Per-stage: 100 * 1.553773974
             enabled: true,
         };
 
@@ -968,21 +1081,84 @@ mod tests {
             imuf: Some(imuf_config),
         };
 
-        let curves = generate_individual_filter_curves(&axis_config, 1000.0, 100);
-        assert!(!curves.is_empty()); // Should have at least header curve, possibly more
+        let curves = generate_individual_filter_curves(&axis_config, 1000.0, 100, true);
+        assert!(!curves.is_empty()); // Should have at least combined curve, possibly per-stage too
 
-        // Check header curve
-        let (header_label, _curve_points, header_cutoff) = &curves[0];
-        assert!(header_label.contains("IMUF v256 Header"));
-        assert!(header_label.contains("PT2"));
-        assert!(header_label.contains("100Hz"));
-        assert_eq!(*header_cutoff, 100.0);
+        // Check combined response curve (red line - shows user-configured PT2 @ 100Hz)
+        let (combined_label, _curve_points, combined_cutoff) = &curves[0];
+        assert!(combined_label.contains("IMUF v256"));
+        assert!(combined_label.contains("PT2")); // Should say "PT2" for user-configured filter
+        assert!(combined_label.contains("100Hz"));
+        assert!(!combined_label.contains("per-stage")); // Combined curve shouldn't have per-stage
+        assert_eq!(*combined_cutoff, 100.0);
 
-        // Check for effective curve if different enough
+        // Check for per-stage curve if different enough (gray line - shows Two PT1 @ 155Hz)
         if curves.len() > 1 {
-            let (effective_label, _, effective_cutoff) = &curves[1];
-            assert!(effective_label.contains("IMUF v256 Effective"));
-            assert!(*effective_cutoff > 150.0); // Should be scaled up
+            let (stage_label, _, stage_cutoff) = &curves[1];
+            assert!(stage_label.contains("IMUF v256"));
+            assert!(stage_label.contains("Two PT1")); // Should say "Two PT1" for per-stage breakdown
+            assert!(stage_label.contains("per-stage"));
+            assert!(*stage_cutoff > 150.0); // Should be scaled up for Butterworth correction
         }
+    }
+
+    #[test]
+    fn test_ptn_filter_curves_generation() {
+        // Test that PT2 generates both main and per-stage curves
+        let lpf1_pt2 = FilterConfig {
+            filter_type: FilterType::PT2,
+            cutoff_hz: 100.0,
+            enabled: true,
+        };
+
+        let axis_config_pt2 = AxisFilterConfig {
+            lpf1: Some(lpf1_pt2),
+            lpf2: None,
+            dynamic_lpf1: None,
+            imuf: None,
+        };
+
+        let curves = generate_individual_filter_curves(&axis_config_pt2, 1000.0, 100, true);
+        assert_eq!(
+            curves.len(),
+            2,
+            "PT2 should generate 2 curves (main + per-stage)"
+        );
+
+        let (main_label, _, main_cutoff) = &curves[0];
+        assert!(main_label.contains("LPF1"));
+        assert!(main_label.contains("PT2"));
+        assert!(main_label.contains("100Hz"));
+        assert!(!main_label.contains("per-stage"));
+        assert_eq!(*main_cutoff, 100.0);
+
+        let (stage_label, _, stage_cutoff) = &curves[1];
+        assert!(stage_label.contains("LPF1"));
+        assert!(stage_label.contains("Two PT1"));
+        assert!(stage_label.contains("per-stage"));
+        assert!(*stage_cutoff > 150.0);
+
+        // Test that PT1 generates only main curve
+        let lpf1_pt1 = FilterConfig {
+            filter_type: FilterType::PT1,
+            cutoff_hz: 100.0,
+            enabled: true,
+        };
+
+        let axis_config_pt1 = AxisFilterConfig {
+            lpf1: Some(lpf1_pt1),
+            lpf2: None,
+            dynamic_lpf1: None,
+            imuf: None,
+        };
+
+        let curves_pt1 = generate_individual_filter_curves(&axis_config_pt1, 1000.0, 100, false);
+        assert_eq!(
+            curves_pt1.len(),
+            1,
+            "PT1 should generate only 1 curve (no per-stage)"
+        );
+        assert!(curves_pt1[0].0.contains("PT1"));
+        assert!(!curves_pt1[0].0.contains("per-stage"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ use crate::data_analysis::calc_step_response;
 
 fn print_usage_and_exit(program_name: &str) {
     eprintln!("
-Usage: {program_name} <input_file1.csv> [<input_file2.csv> ...] [--dps <value>] [--output-dir <directory>] [--debug]");
+Usage: {program_name} <input_file1.csv> [<input_file2.csv> ...] [--dps <value>] [--output-dir <directory>] [--butterworth] [--debug]");
     eprintln!("  <input_fileX.csv>: Path to one or more input CSV log files (required).");
     eprintln!("  --dps <value>: Optional. Enables detailed step response plots with the specified");
     eprintln!("                 deg/s threshold value. Must be a positive number.");
@@ -82,6 +82,10 @@ Usage: {program_name} <input_file1.csv> [<input_file2.csv> ...] [--dps <value>] 
         "  --output-dir <directory>: Optional. Specifies the output directory for generated plots."
     );
     eprintln!("                         If omitted, plots are saved in the source folder (input file's directory).");
+    eprintln!(
+        "  --butterworth: Optional. Show Butterworth per-stage PT1 cutoffs for PT2/PT3/PT4 filters"
+    );
+    eprintln!("                 as gray curves/lines on gyro and D-term spectrum plots.");
     eprintln!("  --debug: Optional. Shows detailed metadata information during processing.");
     eprintln!("  --help: Show this help message and exit.");
     eprintln!("  --version: Show version information and exit.");
@@ -108,6 +112,7 @@ fn process_file(
     use_dir_prefix: bool,
     output_dir: Option<&Path>,
     debug_mode: bool,
+    show_butterworth: bool,
 ) -> Result<(), Box<dyn Error>> {
     // --- Setup paths and names ---
     let input_path = Path::new(input_file_str);
@@ -344,6 +349,7 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
         &root_name_string,
         sample_rate,
         Some(&header_metadata),
+        show_butterworth,
     )?;
     plot_d_term_psd(
         &all_log_data,
@@ -357,6 +363,7 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
         &root_name_string,
         sample_rate,
         Some(&header_metadata),
+        show_butterworth,
     )?;
     plot_psd(&all_log_data, &root_name_string, sample_rate)?;
     plot_psd_db_heatmap(&all_log_data, &root_name_string, sample_rate)?;
@@ -382,6 +389,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut dps_flag_present = false;
     let mut output_dir: Option<String> = None; // None = not specified (use source folder), Some(dir) = --output-dir with value
     let mut debug_mode = false;
+    let mut show_butterworth = false;
 
     let mut i = 1;
     while i < args.len() {
@@ -428,6 +436,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
         } else if arg == "--debug" {
             debug_mode = true;
+        } else if arg == "--butterworth" {
+            show_butterworth = true;
         } else if arg.starts_with("--") {
             eprintln!("Error: Unknown option '{arg}'");
             print_usage_and_exit(program_name);
@@ -492,6 +502,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             use_dir_prefix_for_root_name,
             actual_output_dir,
             debug_mode,
+            show_butterworth,
         ) {
             eprintln!("An error occurred while processing {input_file_str}: {e}");
             overall_success = false;

--- a/src/plot_functions/plot_d_term_spectrums.rs
+++ b/src/plot_functions/plot_d_term_spectrums.rs
@@ -30,6 +30,7 @@ pub fn plot_d_term_spectrums(
     root_name: &str,
     sample_rate: Option<f64>,
     header_metadata: Option<&[(String, String)]>,
+    show_butterworth: bool,
 ) -> Result<(), Box<dyn Error>> {
     // Input validation
     if log_data.is_empty() {
@@ -312,6 +313,7 @@ pub fn plot_d_term_spectrums(
                     &config.dterm[axis_idx],
                     max_freq,
                     num_points,
+                    show_butterworth,
                 );
 
                 // Add each filter curve as a separate series

--- a/src/plot_functions/plot_gyro_spectrums.rs
+++ b/src/plot_functions/plot_gyro_spectrums.rs
@@ -29,6 +29,7 @@ pub fn plot_gyro_spectrums(
     root_name: &str,
     sample_rate: Option<f64>,
     header_metadata: Option<&[(String, String)]>,
+    show_butterworth: bool,
 ) -> Result<(), Box<dyn Error>> {
     let output_file = format!("{root_name}_Gyro_Spectrums_comparative.png");
     let plot_type_name = "Gyro Spectrums";
@@ -389,6 +390,7 @@ pub fn plot_gyro_spectrums(
                     &config.gyro[axis_index],
                     max_freq,
                     num_points,
+                    show_butterworth,
                 );
 
                 // Add each filter curve as a separate series
@@ -419,11 +421,11 @@ pub fn plot_gyro_spectrums(
                             })
                             .collect();
 
-                        // Create filter response series - use gray for effective curves
-                        let curve_color = if label.contains("IMUF v256 Effective") {
-                            RGBColor(128, 128, 128) // Gray for calculated effective curves
+                        // Create filter response series - use gray for per-stage curves
+                        let curve_color = if label.contains("per-stage") {
+                            RGBColor(128, 128, 128) // Gray for per-stage PT1 cutoffs
                         } else {
-                            filter_colors[curve_idx % filter_colors.len()] // Standard colors for user-configured curves
+                            filter_colors[curve_idx % filter_colors.len()] // Standard colors for combined response curves
                         };
 
                         unfilt_plot_series.push(PlotSeries {
@@ -439,14 +441,13 @@ pub fn plot_gyro_spectrums(
                             continue;
                         }
 
-                        // Use dotted line and different color for IMUF effective cutoffs
-                        let (cutoff_prefix, cutoff_color) = if label.contains("IMUF v256 Effective")
-                        {
-                            // Effective cutoffs: dotted line with muted gray color to show they're calculated
+                        // Use dotted line and different color for IMUF per-stage cutoffs
+                        let (cutoff_prefix, cutoff_color) = if label.contains("per-stage") {
+                            // Per-stage cutoffs: dotted line with muted gray color to show Butterworth correction
                             (CUTOFF_LINE_DOTTED_PREFIX, RGBColor(128, 128, 128))
-                        // Gray for calculated values
+                        // Gray for per-stage values
                         } else {
-                            // Header cutoffs: solid line with filter color to show user configuration
+                            // Combined cutoffs: solid line with filter color to show effective response
                             (
                                 CUTOFF_LINE_PREFIX,
                                 filter_colors[curve_idx % filter_colors.len()],


### PR DESCRIPTION
- Adds `--butterworth` command-line parameter to optionally display Butterworth per-stage PT1 cutoff visualization for PT2/PT3/PT4 filters.
- Applies to both gyro and D-term spectrum plots for all firmware (Betaflight, EmuFlight, INAV).
- Per-stage curves are shown in gray with ≈ prefix, main curves show user-configured response.
- Updates documentation and help output to reflect new feature.
- Refactors filter response code to support conditional rendering of per-stage curves.
- All tests and clippy checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a --butterworth option to enable per-stage Butterworth-corrected filter visualization across gyro and D-term spectrum plots and step response.
  - Shows main vs per-stage curves with distinct cutoff line styles, clearer legends, and IMUF version labeling when available.

- **Documentation**
  - Expanded docs with Butterworth Correction Visualization, per-stage PT2/PT3/PT4 math and visualization notes.
  - Updated README usage/examples to mention --butterworth and --debug (documentation only).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->