### PR TITLE
Refactor: Add helper function for debug suffix formatting

### DIFF
--- a/src/plot_functions/mod.rs
+++ b/src/plot_functions/mod.rs
@@ -13,4 +13,19 @@ pub mod plot_setpoint_vs_gyro;
 pub mod plot_step_response;
 pub mod plot_throttle_freq_heatmap;
 
-// src/plot_functions/mod.rs
+// Helper function for formatting debug suffix in plot labels
+pub fn format_debug_suffix(
+    base_label: &str,
+    using_debug_fallback: bool,
+    debug_mode_name: Option<&str>,
+) -> String {
+    if using_debug_fallback {
+        if let Some(mode_name) = debug_mode_name {
+            format!("{} [Debug={}]", base_label, mode_name)
+        } else {
+            format!("{} [Debug]", base_label)
+        }
+    } else {
+        base_label.to_string()
+    }
+}

--- a/src/plot_functions/plot_d_term_psd.rs
+++ b/src/plot_functions/plot_d_term_psd.rs
@@ -414,15 +414,11 @@ pub fn plot_d_term_psd(
                         } else {
                             format!("Unfiltered D-term | {}", delay_str)
                         };
-                        if using_debug_fallback {
-                            if let Some(ref mode_name) = debug_mode_name_owned {
-                                format!("{} [Debug={}]", label_base, mode_name)
-                            } else {
-                                format!("{} [Debug]", label_base)
-                            }
-                        } else {
-                            label_base
-                        }
+                        super::format_debug_suffix(
+                            &label_base,
+                            using_debug_fallback,
+                            debug_mode_name_owned.as_deref(),
+                        )
                     },
                     color: *COLOR_D_TERM_UNFILT,
                     stroke_width: 2,

--- a/src/plot_functions/plot_d_term_spectrums.rs
+++ b/src/plot_functions/plot_d_term_spectrums.rs
@@ -307,15 +307,11 @@ pub fn plot_d_term_spectrums(
                     } else {
                         format!("Unfiltered D-term | {}", delay_str)
                     };
-                    if using_debug_fallback {
-                        if let Some(ref mode_name) = debug_mode_name_owned {
-                            format!("{} [Debug={}]", label_base, mode_name)
-                        } else {
-                            format!("{} [Debug]", label_base)
-                        }
-                    } else {
-                        label_base
-                    }
+                    super::format_debug_suffix(
+                        &label_base,
+                        using_debug_fallback,
+                        debug_mode_name_owned.as_deref(),
+                    )
                 },
                 color: *COLOR_D_TERM_UNFILT,
                 stroke_width: 2,

--- a/src/plot_functions/plot_gyro_spectrums.rs
+++ b/src/plot_functions/plot_gyro_spectrums.rs
@@ -388,39 +388,25 @@ pub fn plot_gyro_spectrums(
                 data: unfilt_series_data,
                 label: {
                     // Check if dynamic LPF is being used to enhance the legend
-                    if let Some(ref config) = filter_config {
+                    let base_label = if let Some(ref config) = filter_config {
                         let (has_dynamic, min_cutoff, max_cutoff) =
                             filter_response::check_gyro_dynamic_lpf_usage(config);
-                        let base_label = if has_dynamic {
+                        if has_dynamic {
                             format!(
                                 "Unfiltered Gyro (Dynamic LPF {:.0}-{:.0}Hz)",
                                 min_cutoff, max_cutoff
                             )
                         } else {
                             "Unfiltered Gyro".to_string()
-                        };
-
-                        if using_debug_fallback {
-                            if let Some(ref mode_name) = debug_mode_name_owned {
-                                format!("{} [Debug={}]", base_label, mode_name)
-                            } else {
-                                format!("{} [Debug]", base_label)
-                            }
-                        } else {
-                            base_label
                         }
                     } else {
-                        let base_label = "Unfiltered Gyro".to_string();
-                        if using_debug_fallback {
-                            if let Some(ref mode_name) = debug_mode_name_owned {
-                                format!("{} [Debug={}]", base_label, mode_name)
-                            } else {
-                                format!("{} [Debug]", base_label)
-                            }
-                        } else {
-                            base_label
-                        }
-                    }
+                        "Unfiltered Gyro".to_string()
+                    };
+                    super::format_debug_suffix(
+                        &base_label,
+                        using_debug_fallback,
+                        debug_mode_name_owned.as_deref(),
+                    )
                 },
                 color: *COLOR_GYRO_VS_UNFILT_UNFILT,
                 stroke_width: LINE_WIDTH_PLOT,

--- a/src/plot_functions/plot_gyro_vs_unfilt.rs
+++ b/src/plot_functions/plot_gyro_vs_unfilt.rs
@@ -105,15 +105,11 @@ pub fn plot_gyro_vs_unfilt(
             let mut series = Vec::new();
             if !unfilt_series_data.is_empty() {
                 // Create label with debug mode annotation if using debug fallback
-                let unfilt_label = if using_debug_fallback {
-                    if let Some(ref mode_name) = debug_mode_name_owned {
-                        format!("Unfiltered Gyro [Debug={}]", mode_name)
-                    } else {
-                        "Unfiltered Gyro [Debug]".to_string()
-                    }
-                } else {
-                    "Unfiltered Gyro (gyroUnfilt)".to_string()
-                };
+                let unfilt_label = super::format_debug_suffix(
+                    "Unfiltered Gyro (gyroUnfilt)",
+                    using_debug_fallback,
+                    debug_mode_name_owned.as_deref(),
+                );
 
                 series.push(PlotSeries {
                     data: unfilt_series_data,

--- a/src/plot_functions/plot_psd.rs
+++ b/src/plot_functions/plot_psd.rs
@@ -354,18 +354,11 @@ pub fn plot_psd(
 
             let unfilt_plot_series = vec![PlotSeries {
                 data: unfilt_psd_data,
-                label: {
-                    let base_label = "Unfiltered Gyro PSD".to_string();
-                    if using_debug_fallback {
-                        if let Some(ref mode_name) = debug_mode_name_owned {
-                            format!("{} [Debug={}]", base_label, mode_name)
-                        } else {
-                            format!("{} [Debug]", base_label)
-                        }
-                    } else {
-                        base_label
-                    }
-                },
+                label: super::format_debug_suffix(
+                    "Unfiltered Gyro PSD",
+                    using_debug_fallback,
+                    debug_mode_name_owned.as_deref(),
+                ),
                 color: *COLOR_GYRO_VS_UNFILT_UNFILT,
                 stroke_width: LINE_WIDTH_PLOT,
             }];


### PR DESCRIPTION
- Add format_debug_suffix helper in plot_functions/mod.rs
- Replace duplicated debug suffix logic in 5 plot files
- Eliminates code duplication and improves maintainability

resolves #74


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization by centralizing debug label formatting logic across plot generation functions for enhanced consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->