### PR TITLE
feat: Support Betaflight date-versioning (datever) format with backward compatibility

### DIFF
--- a/src/debug_mode_lookup.rs
+++ b/src/debug_mode_lookup.rs
@@ -16,6 +16,9 @@ enum FirmwareVersion {
     Unknown,
 }
 
+/// Formats the parsed version components.
+/// Note: This does not preserve version suffixes (e.g., "-beta", "-rc1").
+/// Use the version_str from parse_firmware_revision if you need the original string.
 impl fmt::Display for FirmwareVersion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {


### PR DESCRIPTION
- Add Display trait for FirmwareVersion enum to properly format versions
- Update parse_firmware_revision to return original version string
- Maintain backward compatibility with semver format
- Add comprehensive tests for datever parsing and display

Resolves #75 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved firmware version parsing and display so versions show concise, user-friendly formats (e.g., numeric pairs and date-style versions; unknown values labeled "Unknown").
  * Parsing now preserves an additional plain-text version string for clearer reporting and comparisons.
* **Tests**
  * Expanded tests to validate displayed version formatting and the additional version string across firmware types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->