### PR TITLE
fix: format D-Term Spectrums vertical index as whole number (XXM)

### DIFF
--- a/src/plot_framework.rs
+++ b/src/plot_framework.rs
@@ -191,7 +191,7 @@ fn draw_single_axis_chart_with_config(
             // Use decimal formatting for normalized response values (step response plots)
             if !plot_config.y_label.contains("dB") {
                 if y.abs() >= 1_000_000.0 {
-                    format!("{:.1}M", y / 1_000_000.0)
+                    format!("{:.0}M", y / 1_000_000.0)
                 } else if y.abs() >= 1000.0 {
                     format!("{:.0}k", y / 1000.0)
                 } else if y.abs() < 10.0


### PR DESCRIPTION
- resolves #85



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted Y-axis number formatting on charts for large values (millions) to display whole numbers without decimal places, improving readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->