### PR TITLE
feat: Auto-skip .header.csv and .headers.csv files (Resolves #82)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -258,21 +258,19 @@ fn find_csv_files_in_dir_impl(
             if let Some(extension) = path.extension() {
                 if extension.to_string_lossy().eq_ignore_ascii_case("csv") {
                     // Skip header files (these are metadata files, not flight logs)
-                    if path.to_str().is_some_and(|s| {
-                        let lowercase = s.to_ascii_lowercase();
-                        lowercase.ends_with(".header.csv") || lowercase.ends_with(".headers.csv")
-                    }) {
-                        if let Some(path_str) = path.to_str() {
+                    if let Some(path_str) = path.to_str() {
+                        let lowercase = path_str.to_ascii_lowercase();
+                        if lowercase.ends_with(".header.csv") || lowercase.ends_with(".headers.csv")
+                        {
                             eprintln!("Warning: Skipping header file: {}", path_str);
+                        } else {
+                            csv_files.push(path_str.to_string());
                         }
                     } else {
-                        match path.to_str() {
-                            Some(path_str) => csv_files.push(path_str.to_string()),
-                            None => eprintln!(
-                                "Warning: Skipping file with non-UTF-8 path: {}",
-                                path.display()
-                            ),
-                        }
+                        eprintln!(
+                            "Warning: Skipping file with non-UTF-8 path: {}",
+                            path.display()
+                        );
                     }
                 }
             }


### PR DESCRIPTION
- Add check to skip both .header.csv and .headers.csv file patterns
- File input validation: skip with warning message
- Directory scanning: skip with warning message (consistent messaging)
- Prevents processing of metadata files as flight logs
- resolves #82


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Filter out header metadata CSV files (e.g., .header.csv, .headers.csv) during file processing and directory traversal; warnings are issued for each skipped header file.
  * Preserve previous behavior for non-header CSVs and non-CSV paths (warnings unchanged).

* **Refactor**
  * Ensure CSV file results are returned in a deterministic, sorted order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->