### PR TITLE
fix: Remove peak finding and rendering from filtered PNG plots (issue…

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -62,6 +62,7 @@ pub const PEAK_LABEL_MIN_AMPLITUDE: f64 = 1000.0; // Ignore peaks under this; Tu
 pub const FILTERED_D_TERM_MIN_THRESHOLD: f64 = 100000.0; // Filtered D-term peaks below 100k (0.1% of typical 100M unfiltered) are not meaningful
 
 // Intelligent threshold for filtered gyro peak detection
+#[allow(dead_code)]
 pub const FILTERED_GYRO_MIN_THRESHOLD: f64 = 2000.0; // Filtered gyro peaks below 2k are typically noise (based on user feedback)
 
 // Constants for PSD plots (dB scale)

--- a/src/plot_functions/plot_d_term_psd.rs
+++ b/src/plot_functions/plot_d_term_psd.rs
@@ -319,13 +319,9 @@ pub fn plot_d_term_psd(
             "Unfiltered D-term PSD",
             PSD_PEAK_LABEL_MIN_VALUE_DB,
         );
-        let filt_peaks = find_and_sort_peaks_with_threshold(
-            &filt_series_data,
-            filt_primary_peak,
-            axis_name,
-            "Filtered D-term PSD",
-            PSD_PEAK_LABEL_MIN_VALUE_DB,
-        );
+        // Per issue #92: Skip peak detection on filtered plots entirely - they won't be rendered
+        let _filt_primary_peak = filt_primary_peak;
+        let filt_peaks = Vec::new();
 
         // Get delay string for this axis for legend display
         let delay_str = if any_delay_calculated {
@@ -458,8 +454,8 @@ pub fn plot_d_term_psd(
                 x_label: "Frequency (Hz)".to_string(),
                 y_label: "Power Spectral Density (dB/Hz)".to_string(),
                 peaks: filt_peaks,
-                peak_label_threshold: Some(PSD_PEAK_LABEL_MIN_VALUE_DB),
-                peak_label_format_string: Some("{:.0}dB".to_string()),
+                peak_label_threshold: None, // No peak labels on filtered plot per issue #92
+                peak_label_format_string: None,
                 frequency_ranges: None,
             })
         } else {

--- a/src/plot_functions/plot_d_term_spectrums.rs
+++ b/src/plot_functions/plot_d_term_spectrums.rs
@@ -259,13 +259,9 @@ pub fn plot_d_term_spectrums(
             "Unfiltered D-term Spectrum",
             PEAK_LABEL_MIN_AMPLITUDE,
         );
-        let filt_peaks = find_and_sort_peaks_with_threshold(
-            &filt_series_data,
-            filt_primary_peak,
-            axis_name,
-            "Filtered D-term Spectrum",
-            PEAK_LABEL_MIN_AMPLITUDE,
-        );
+        // Per issue #92: Skip peak detection on filtered plots entirely - they won't be rendered
+        let _filt_primary_peak = filt_primary_peak;
+        let filt_peaks = Vec::new();
 
         // Get delay string for this axis for legend display
         let delay_str = if let Some(result) = delay_by_axis.get(axis_idx).and_then(|r| r.as_ref()) {
@@ -490,8 +486,8 @@ pub fn plot_d_term_spectrums(
                 x_label: "Frequency (Hz)".to_string(),
                 y_label: "Amplitude".to_string(),
                 peaks: filt_peaks,
-                peak_label_threshold: Some(PEAK_LABEL_MIN_AMPLITUDE),
-                peak_label_format_string: Some("{:.0}".to_string()),
+                peak_label_threshold: None, // No peak labels on filtered plot per issue #92
+                peak_label_format_string: None,
                 frequency_ranges: None,
             })
         } else {

--- a/src/plot_functions/plot_gyro_spectrums.rs
+++ b/src/plot_functions/plot_gyro_spectrums.rs
@@ -5,8 +5,8 @@ use std::error::Error;
 
 use crate::axis_names::AXIS_NAMES;
 use crate::constants::{
-    COLOR_GYRO_VS_UNFILT_FILT, COLOR_GYRO_VS_UNFILT_UNFILT, FILTERED_GYRO_MIN_THRESHOLD,
-    LINE_WIDTH_PLOT, PEAK_LABEL_MIN_AMPLITUDE, SPECTRUM_NOISE_FLOOR_HZ, SPECTRUM_Y_AXIS_FLOOR,
+    COLOR_GYRO_VS_UNFILT_FILT, COLOR_GYRO_VS_UNFILT_UNFILT, LINE_WIDTH_PLOT,
+    PEAK_LABEL_MIN_AMPLITUDE, SPECTRUM_NOISE_FLOOR_HZ, SPECTRUM_Y_AXIS_FLOOR,
     SPECTRUM_Y_AXIS_HEADROOM_FACTOR, TUKEY_ALPHA,
 };
 use crate::data_analysis::calc_step_response; // For tukeywin
@@ -163,13 +163,8 @@ pub fn plot_gyro_spectrums(
             "Unfiltered",
             PEAK_LABEL_MIN_AMPLITUDE,
         );
-        let filt_peaks_for_plot = find_and_sort_peaks_with_threshold(
-            &filt_series_data,
-            primary_peak_filt,
-            axis_name,
-            "Filtered",
-            FILTERED_GYRO_MIN_THRESHOLD,
-        );
+        // Per issue #92: Skip peak detection on filtered plots entirely - they won't be rendered
+        let filt_peaks_for_plot = Vec::new();
 
         let noise_floor_sample_idx = (SPECTRUM_NOISE_FLOOR_HZ / freq_step).max(0.0) as usize;
         let max_amp_after_noise_floor_unfilt = unfilt_series_data
@@ -553,9 +548,8 @@ pub fn plot_gyro_spectrums(
                 x_label: "Frequency (Hz)".to_string(),
                 y_label: "Amplitude".to_string(),
                 peaks: filt_peaks,
-                // Use FILTERED_GYRO_MIN_THRESHOLD for filtered plot labeling threshold
-                peak_label_threshold: Some(FILTERED_GYRO_MIN_THRESHOLD),
-                peak_label_format_string: Some("{:.0}".to_string()),
+                peak_label_threshold: None, // No peak labels on filtered plot per issue #92
+                peak_label_format_string: None,
                 frequency_ranges: None, // No dynamic notch on filtered plot (already applied)
             });
 

--- a/src/plot_functions/plot_psd.rs
+++ b/src/plot_functions/plot_psd.rs
@@ -167,13 +167,8 @@ pub fn plot_psd(
             "Unfiltered",
             PSD_PEAK_LABEL_MIN_VALUE_DB,
         );
-        let filt_peaks_for_plot = find_and_sort_peaks_with_threshold(
-            &filt_psd_data,
-            primary_peak_filt_db,
-            axis_name,
-            "Filtered",
-            PSD_PEAK_LABEL_MIN_VALUE_DB,
-        );
+        // Per issue #92: Skip peak detection on filtered plots entirely - they won't be rendered
+        let filt_peaks_for_plot = Vec::new();
 
         let noise_floor_sample_idx = (SPECTRUM_NOISE_FLOOR_HZ / freq_step).max(0.0) as usize;
         let max_val_after_noise_floor_unfilt_db = unfilt_psd_data
@@ -305,8 +300,8 @@ pub fn plot_psd(
                 x_label: "Frequency (Hz)".to_string(),
                 y_label: "Power/Frequency (dB)".to_string(),
                 peaks: filt_peaks,
-                peak_label_threshold: Some(PSD_PEAK_LABEL_MIN_VALUE_DB),
-                peak_label_format_string: Some("{:.2} dB".to_string()),
+                peak_label_threshold: None, // No peak labels on filtered plot per issue #92
+                peak_label_format_string: None,
                 frequency_ranges: None,
             });
 


### PR DESCRIPTION
… #92, CodeRabbit recommendation). Only unfiltered plots retain peak detection and rendering. Console output for filtered peaks also suppressed.

resolves #92 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Peak labels no longer display on filtered data visualizations across D-term PSD, D-term spectrum, gyro spectrum, and PSD charts.

* **Chores**
  * Code quality improvements made to linting configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->