### PR TITLE
fix: make --step and --motor CLI flags combinable

### DIFF
--- a/src/data_input/log_parser.rs
+++ b/src/data_input/log_parser.rs
@@ -427,7 +427,7 @@ pub fn parse_log_file(input_file_path: &Path, debug_mode: bool) -> LogParseResul
             && debug_header_found.iter().take(3).any(|&found| found);
 
         if using_debug_fallback {
-            println!("\n⚠ Using debug[0-2] as fallback for gyroUnfilt[0-2]");
+            println!("\n⚠️ Using debug[0-2] as fallback for gyroUnfilt[0-2]");
 
             // Try to report which debug mode is being used
             if let Some((_, debug_mode_value)) =


### PR DESCRIPTION
Previously, the --step and --motor flags were mutually exclusive, with the last specified flag overriding earlier ones. This fix allows both flags to be combined to generate both step response and motor spectrum plots.

Changes:
- Replace step_only() and motor_only() methods with a single none() method that disables all plots
- Track which 'only' flags were specified during argument parsing
- After parsing, if any 'only' flags were present, start from none() and enable only the requested plot types
- This maintains backward compatibility (single flags still work as before) while enabling combination usage

Resolves #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Updated plot configuration preset behavior; `--step` and `--motor` command-line flags now use revised initialization logic.

## Style
* Updated warning message styling with refined emoji formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->