### PR TITLE
fix: Correct Bode plot phase sign inversion in H1 estimator (Resolve #130)

### DIFF
--- a/src/data_analysis/transfer_function_estimation.rs
+++ b/src/data_analysis/transfer_function_estimation.rs
@@ -262,10 +262,10 @@ pub fn estimate_transfer_function_h1(
         let psd_input = psd_xx[i].1;
 
         if psd_input > PSD_EPSILON {
-            // cpsd_yx from welch_cpsd computes: Gyro(f) * conj(Setpoint(f))
-            // But we need: conj(Setpoint(f)) * Gyro(f) for correct phase
-            // These differ by conjugation, so conjugate cpsd to get correct phase sign
-            let h1 = cpsd.conj() / psd_input;
+            // welch_cpsd already computes Syx = Gyro(f) * conj(Setpoint(f))
+            // H1 estimator: H1(f) = Syx(f) / Sxx(f)
+            // Phase: ∠H1 = ∠Gyro - ∠Setpoint (negative for systems with delay)
+            let h1 = cpsd / psd_input;
             h1_complex.push(h1);
             frequency_hz.push(*freq);
             // Keep coherence value aligned with frequency and magnitude


### PR DESCRIPTION
## Problem
Bode plot phase values were showing **positive phase** (incorrect) when they should show **negative phase** (correct) for delayed control systems.

## Root Cause
A spurious `.conj()` operation in the H1 estimator was inverting the phase sign. The `welch_cpsd` function already computes the correct cross-power spectral density `Syx = Gyro(f) × conj(Setpoint(f))`, but the code was applying an unnecessary conjugation that flipped the phase.

## Solution
Removed the incorrect `.conj()` call and updated comments with clear mathematical explanation.

**Before (buggy):**
```rust
let h1 = cpsd.conj() / psd_input;  // Extra conjugation inverts phase!
```

**After (correct):**
```rust
let h1 = cpsd / psd_input;  // Correct H1(f) = Syx(f) / Sxx(f)
```

## Mathematical Correctness
The H1 estimator formula is: **H₁(f) = Syx(f) / Sxx(f)**

With our fix:
- Phase relationship: **∠H₁ = ∠Gyro - ∠Setpoint** ✓
- For delayed systems: **∠H₁ < 0°** (negative phase as expected) ✓

## Testing
✅ All tests **PASS** with `--bode` parameter:
- BHEF405PRO (62MB) → Bode plot generated, phase = NEGATIVE ✓
- Chirp 01 (6.1MB) → Bode plot generated, phase = NEGATIVE ✓  
- Chirp 02 (11MB) → Bode plot generated, phase = NEGATIVE ✓

✅ Code quality checks pass:
- `cargo build --release` - Success
- `cargo clippy` - No warnings
- `cargo fmt` - Applied

## Impact
- ✅ Stability margins now correctly calculated
- ✅ Nyquist stability criterion properly applicable
- ✅ Phase values match physical system behavior
- ✅ No breaking changes or regressions

## References
- Bendat & Piersol (2010) - Random Data: Analysis and Measurement Procedures, Eq. 9.17
- IEEE Control Systems Standards - Bode plot phase convention
- Åström & Murray (2008) - Feedback Systems

Resolve #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined H1 estimator computation in transfer function estimation for improved accuracy in frequency response calculations and phase information handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->