### PR TITLE
Step Response: Rework tuning zones, recommendations, and thresholds

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -66,17 +66,17 @@ All analysis parameters, thresholds, plot dimensions, and algorithmic constants 
         * **P:D Ratio Recommendations (`src/main.rs`):**
             * Based on step response peak analysis, the system provides tuning recommendations:
                 * **Important:** Peak value is measured as the first maximum after the response crosses the setpoint (1.0). The initial transient dip (visible in first ~30ms) is normal system behavior and not used for tuning recommendations.
-                * **Peak Analysis Ranges (based on step response overshoot/undershoot):**
-                    * Peak > 1.20: Significant overshoot (>20%) → P:D×0.85 (increase D by ~18%)
-                    * Peak 1.16-1.20: Moderate overshoot (16-20%) → P:D×0.88 (increase D by ~14%)
-                    * Peak 1.11-1.15: Minor overshoot (11-15%) → P:D×0.92 (increase D by ~9%)
-                    * Peak 1.05-1.10: Acceptable response (5-10% overshoot) → P:D×0.95 (increase D by ~5%)
-                    * Peak 0.95-1.04: Optimal response (0-5% overshoot/undershoot) → No change (ideal damping)
-                    * Peak 0.85-0.94: Minor undershoot (6-15%) → P:D×1.05 (decrease D by ~5%)
-                    * Peak < 0.85: Significant undershoot (>15%) → P:D×1.15 (decrease D by ~13%)
-                * **Dual Recommendations:**
-                    * **Conservative** (PD_RATIO_CONSERVATIVE_MULTIPLIER = 0.85): Reduces P:D ratio by 15%, increasing D by ~18%. Safe for most pilots, 2-3 iterations to optimal.
-                    * **Moderate** (PD_RATIO_MODERATE_MULTIPLIER = 0.75): Reduces P:D ratio by 25%, increasing D by ~33%. For experienced pilots, 1-2 iterations to optimal.
+                * **Peak Analysis Ranges (based on step response overshoot/undershoot):** Simplified 6-zone structure aligned with real-world practical tuning:
+                    * **< 1.00 (Undershoot):** Too much D damping. Recommendation (conservative): P:D × (1.05 / peak) — proportional decrease targeting sweet-spot centre.
+                    * **1.00–1.02 (Near Optimal):** Critically damped transition zone. Recommendation (none) + optional D−1 hint for fine-tuning.
+                    * **1.02–1.08 (Optimal / Pro Sweet Spot):** Ideal response with responsive feel. Recommendation (none) — no adjustment needed.
+                    * **1.08–1.12 (Acceptable):** Slight bounce but still locked-in. Recommendation (conservative): P:D×0.98 (increase D by ~2%).
+                    * **1.12–1.20 (Overshoot):** Visible overshoot but manageable. Recommendation (conservative): P:D×0.92 (increase D by ~8.7%) + Recommendation (moderate): P:D×0.75 (increase D by ~33%).
+                    * **> 1.20 (Significant Overshoot):** Excessive oscillation indicating P is too high. Recommendation (conservative) + (moderate) + Recommendation (aggressive): P:D×0.65 (increase D by ~54%).
+                * **Multi-Tiered Recommendations:**
+                    * **Conservative** (PD_RATIO_CONSERVATIVE_MULTIPLIER = 0.85): Reduces P:D ratio by 15%, increasing D by ~18%. Safe for most pilots.
+                    * **Moderate** (PD_RATIO_MODERATE_MULTIPLIER = 0.75): Reduces P:D ratio by 25%, increasing D by ~33%. For experienced pilots.
+                    * **Aggressive** (PD_RATIO_AGGRESSIVE_MULTIPLIER = 0.65): Reduces P:D ratio by 35%, increasing D by ~54%. For tuning significant overshoot zones (>1.20).
                 * **D-Min/D-Max Support:**
                     * Automatically detects if D-Min/D-Max system is enabled (Betaflight 4.0+)
                     * When enabled: Recommends proportional D-Min and D-Max values maintaining current ratio relationships

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -221,26 +221,24 @@ pub const PD_RATIO_MIN_CHANGE_THRESHOLD: f64 = 0.05; // Minimum P:D ratio change
 // Note: Works for all aircraft sizes including 10"+ where D > P (P:D < 1.0)
 pub const PD_RATIO_CONSERVATIVE_MULTIPLIER: f64 = 0.85; // Conservative: reduce P:D by 15% (≈+17.6% D)
 pub const PD_RATIO_MODERATE_MULTIPLIER: f64 = 0.75; // Moderate: reduce P:D by 25% (≈+33.3% D)
+pub const PD_RATIO_AGGRESSIVE_MULTIPLIER: f64 = 0.65; // Aggressive: reduce P:D by 35% (≈+53.8% D)
 
-// Peak range adjustment multipliers for different overshoot levels
+// Step response quality zone thresholds
+pub const PEAK_UNDERSHOOT_MAX: f64 = 1.00; // < this = undershoot: Recommendation (conservative) D decrease
+pub const PEAK_OPTIMAL_MIN: f64 = 1.02; // near-optimal ends / sweet spot start; 1.00–1.02 = near optimal (none), 1.02–1.08 = optimal (none)
+#[allow(dead_code)]
+pub const PEAK_OPTIMAL_MAX: f64 = 1.08; // sweet spot end
+pub const PEAK_ACCEPTABLE_MIN: f64 = 1.08; // 1.08–1.12 = acceptable: Recommendation (conservative) D increase
+pub const PEAK_ACCEPTABLE_MAX: f64 = 1.12; // above this = overshoot territory
+pub const PEAK_SIGNIFICANT_MIN: f64 = 1.20; // >= this = significant overshoot: conservative + moderate + aggressive
+
+// Target peak value for undershoot correction: centre of the optimal sweet spot
+pub const PEAK_OPTIMAL_TARGET: f64 = (PEAK_OPTIMAL_MIN + PEAK_OPTIMAL_MAX) / 2.0;
+
+// Peak range adjustment multipliers for different overshoot/undershoot levels
 // These create a graduated response based on step response quality
-pub const PEAK_ACCEPTABLE_MULTIPLIER: f64 = 0.95; // Acceptable (1.05-1.10): Small adjustment, +≈5.3% D
-pub const PEAK_MINOR_MULTIPLIER: f64 = 0.92; // Minor overshoot (1.11-1.15): Moderate adjustment, +≈8.7% D
-pub const PEAK_MODERATE_MULTIPLIER: f64 = 0.88; // Moderate overshoot (1.16-1.20): Larger adjustment, +≈13.6% D
-
-// Peak range thresholds for step response quality assessment
-pub const PEAK_OPTIMAL_MIN: f64 = 0.95; // Optimal response: 0.95-1.04 (0-5% overshoot/undershoot)
-#[allow(dead_code)]
-pub const PEAK_OPTIMAL_MAX: f64 = 1.04;
-pub const PEAK_ACCEPTABLE_MIN: f64 = 1.05; // Acceptable: 1.05-1.10 (5-10% overshoot)
-pub const PEAK_ACCEPTABLE_MAX: f64 = 1.10;
-#[allow(dead_code)]
-pub const PEAK_MINOR_MIN: f64 = 1.11; // Minor overshoot: 1.11-1.15 (11-15% overshoot)
-pub const PEAK_MINOR_MAX: f64 = 1.15;
-pub const PEAK_MODERATE_MIN: f64 = 1.16; // Moderate overshoot: 1.16-1.20 (16-20% overshoot)
-#[allow(dead_code)]
-pub const PEAK_MODERATE_MAX: f64 = 1.20;
-pub const PEAK_SIGNIFICANT_MIN: f64 = 1.20; // Significant overshoot: >1.20 (>20% overshoot)
+pub const PEAK_ACCEPTABLE_MULTIPLIER: f64 = 0.98; // Acceptable (PEAK_ACCEPTABLE_MIN–PEAK_ACCEPTABLE_MAX): +≈2% D
+pub const PEAK_OVERSHOOT_MULTIPLIER: f64 = 0.92; // Overshoot (PEAK_ACCEPTABLE_MAX–PEAK_SIGNIFICANT_MIN): +≈8.7% D
 
 // Sanity check limits for P:D ratio recommendations
 // Note: MIN_REASONABLE_PD_RATIO of 0.3 accommodates large aircraft where D > P

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -230,7 +230,7 @@ pub const PEAK_OPTIMAL_MIN: f64 = 1.02; // near-optimal ends / sweet spot start;
 pub const PEAK_OPTIMAL_MAX: f64 = 1.08; // sweet spot end
 pub const PEAK_ACCEPTABLE_MIN: f64 = 1.08; // 1.08–1.12 = acceptable: Recommendation (conservative) D increase
 pub const PEAK_ACCEPTABLE_MAX: f64 = 1.12; // above this = overshoot territory
-pub const PEAK_SIGNIFICANT_MIN: f64 = 1.20; // >= this = significant overshoot: conservative + moderate + aggressive
+pub const PEAK_SIGNIFICANT_MIN: f64 = 1.20; // > this = significant overshoot: conservative + moderate + aggressive
 
 // Target peak value for undershoot correction: centre of the optimal sweet spot
 pub const PEAK_OPTIMAL_TARGET: f64 = (PEAK_OPTIMAL_MIN + PEAK_OPTIMAL_MAX) / 2.0;
@@ -239,6 +239,8 @@ pub const PEAK_OPTIMAL_TARGET: f64 = (PEAK_OPTIMAL_MIN + PEAK_OPTIMAL_MAX) / 2.0
 // These create a graduated response based on step response quality
 pub const PEAK_ACCEPTABLE_MULTIPLIER: f64 = 0.98; // Acceptable (PEAK_ACCEPTABLE_MIN–PEAK_ACCEPTABLE_MAX): +≈2% D
 pub const PEAK_OVERSHOOT_MULTIPLIER: f64 = 0.92; // Overshoot (PEAK_ACCEPTABLE_MAX–PEAK_SIGNIFICANT_MIN): +≈8.7% D
+pub const PEAK_VALUE_MIN_CLAMP: f64 = 0.1; // Minimum peak value clamp to prevent divide-by-zero in undershoot multiplier
+pub const D_STEP_OPTIONAL: u32 = 1; // D decrement for optional near-optimal fine-tune hint
 
 // Sanity check limits for P:D ratio recommendations
 // Note: MIN_REASONABLE_PD_RATIO of 0.3 accommodates large aircraft where D > P

--- a/src/main.rs
+++ b/src/main.rs
@@ -714,10 +714,11 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                 current_pd_ratios[axis_index] = Some(current_pd_ratio);
                                 assessments[axis_index] = Some(assessment);
 
-                                // Always store recommendations for Acceptable zone (2% change never clears
-                                // the 5% threshold but the recommendation is still valid), otherwise
-                                // require a minimum change to avoid noise on already-good responses.
+                                // Always store recommendations for zones where the delta is small by
+                                // design (Acceptable ≈2%, Undershoot near-boundary ≈5% at low P:D)
+                                // to avoid the 5% gate suppressing valid recommendations.
                                 if assessment == "Acceptable"
+                                    || assessment == "Undershoot"
                                     || (recommended_ratio - current_pd_ratio).abs()
                                         > crate::constants::PD_RATIO_MIN_CHANGE_THRESHOLD
                                 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -726,11 +726,13 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                         Some(recommended_ratio);
 
                                     // Calculate moderate recommendation for any overshoot (>PEAK_ACCEPTABLE_MAX)
+                                    // Base directly on current_pd_ratio so the result is always
+                                    // current * PD_RATIO_MODERATE_MULTIPLIER regardless of which
+                                    // conservative-tier multiplier was applied to recommended_ratio.
                                     let moderate_ratio =
                                         if peak_value > crate::constants::PEAK_ACCEPTABLE_MAX {
-                                            let ratio = recommended_ratio
-                                            * crate::constants::PD_RATIO_MODERATE_MULTIPLIER
-                                            / crate::constants::PD_RATIO_CONSERVATIVE_MULTIPLIER;
+                                            let ratio = current_pd_ratio
+                                                * crate::constants::PD_RATIO_MODERATE_MULTIPLIER;
                                             recommended_pd_aggressive[axis_index] = Some(ratio);
                                             Some(ratio)
                                         } else {
@@ -916,43 +918,49 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                                     aggressive_pd, rec_d3, p_val);
                                             }
                                         }
+                                    } else if assessment == "Near optimal" {
+                                        // Near optimal (1.00–1.02): D−1 hint only — no "none" line,
+                                        // since "none" and a concrete suggestion are contradictory.
+                                        if dmax_enabled {
+                                            let d_min_str = axis_pid
+                                                .d_min
+                                                .map(|v| {
+                                                    v.saturating_sub(
+                                                        crate::constants::D_STEP_OPTIONAL,
+                                                    )
+                                                })
+                                                .map_or("N/A".to_string(), |v| v.to_string());
+                                            let d_max_str = axis_pid
+                                                .d_max
+                                                .or(axis_pid.d)
+                                                .map(|v| {
+                                                    v.saturating_sub(
+                                                        crate::constants::D_STEP_OPTIONAL,
+                                                    )
+                                                })
+                                                .map_or("N/A".to_string(), |v| v.to_string());
+                                            println!(
+                                                "  Recommendation (conservative): D-Min≈{}, D-Max≈{} (P={}) [optional D−1]",
+                                                d_min_str, d_max_str, p_val
+                                            );
+                                        } else if let Some(current_d) = axis_pid.d {
+                                            println!(
+                                                "  Recommendation (conservative): D≈{} (P={}) [optional D−1]",
+                                                current_d.saturating_sub(
+                                                    crate::constants::D_STEP_OPTIONAL
+                                                ),
+                                                p_val
+                                            );
+                                        } else {
+                                            println!(
+                                                "  Recommendation (none): No tuning adjustments needed"
+                                            );
+                                        }
                                     } else {
-                                        // Optimal or near-optimal zone — no P:D adjustment needed
+                                        // Optimal zone (1.02–1.08): no adjustment needed
                                         println!(
                                             "  Recommendation (none): No tuning adjustments needed"
                                         );
-                                        // Near optimal (1.00–1.02): suggest D-1 as optional fine-tune
-                                        if assessment == "Near optimal" {
-                                            if dmax_enabled {
-                                                let d_min_str = axis_pid
-                                                    .d_min
-                                                    .map(|v| {
-                                                        v.saturating_sub(
-                                                            crate::constants::D_STEP_OPTIONAL,
-                                                        )
-                                                    })
-                                                    .map_or("N/A".to_string(), |v| v.to_string());
-                                                let d_max_str = axis_pid
-                                                    .d_max
-                                                    .or(axis_pid.d)
-                                                    .map(|v| {
-                                                        v.saturating_sub(
-                                                            crate::constants::D_STEP_OPTIONAL,
-                                                        )
-                                                    })
-                                                    .map_or("N/A".to_string(), |v| v.to_string());
-                                                println!(
-                                                    "  Recommendation (conservative): D-Min≈{}, D-Max≈{} (P={}) [optional D−1]",
-                                                    d_min_str, d_max_str, p_val
-                                                );
-                                            } else if let Some(current_d) = axis_pid.d {
-                                                println!(
-                                                    "  Recommendation (conservative): D≈{} (P={}) [optional D−1]",
-                                                    current_d.saturating_sub(crate::constants::D_STEP_OPTIONAL),
-                                                    p_val
-                                                );
-                                            }
-                                        }
                                     }
                                 } else {
                                     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -951,15 +951,11 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                                 ),
                                                 p_val
                                             );
-                                        } else {
-                                            println!(
-                                                "  Recommendation (none): No tuning adjustments needed"
-                                            );
                                         }
                                     } else {
                                         // Optimal zone (1.02–1.08): no adjustment needed
                                         println!(
-                                            "  Recommendation (none): No tuning adjustments needed"
+                                            "  Recommendation (none): No obvious tuning adjustments needed"
                                         );
                                     }
                                 } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -671,50 +671,42 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
 
                             if let Some(current_pd_ratio) = current_ratio {
                                 // Analyze overshoot/undershoot based on peak response and calculate recommended ratio
-                                // Peak ranges:
-                                //   0.95-1.05 = optimal (0-5% overshoot/undershoot)
-                                //   1.05-1.10 = acceptable (5-10% overshoot, improvable)
-                                //   1.10-1.15 = minor overshoot (11-15%, needs improvement)
-                                //   >1.15     = moderate/severe overshoot (needs significant D increase)
-                                let (assessment, recommended_ratio) = if peak_value
-                                    > crate::constants::PEAK_SIGNIFICANT_MIN
-                                {
-                                    // Significant overshoot (>20%) - use conservative multiplier
-                                    (
+                                // Peak zones (see constants.rs for threshold values):
+                                //   < PEAK_UNDERSHOOT_MAX        = undershoot:   Recommendation (conservative) proportional D decrease
+                                //   PEAK_UNDERSHOOT_MAX..PEAK_OPTIMAL_MIN = near optimal: Recommendation (none)
+                                //   PEAK_OPTIMAL_MIN..PEAK_ACCEPTABLE_MIN = optimal:      Recommendation (none)
+                                //   PEAK_ACCEPTABLE_MIN..PEAK_ACCEPTABLE_MAX = acceptable: Recommendation (conservative)
+                                //   PEAK_ACCEPTABLE_MAX..PEAK_SIGNIFICANT_MIN = overshoot:  Recommendation (conservative)
+                                //   > PEAK_SIGNIFICANT_MIN       = significant:  conservative + moderate + aggressive
+                                let (assessment, recommended_ratio) =
+                                    if peak_value > crate::constants::PEAK_SIGNIFICANT_MIN {
+                                        (
                                         "Significant overshoot",
                                         current_pd_ratio
                                             * crate::constants::PD_RATIO_CONSERVATIVE_MULTIPLIER,
                                     )
-                                } else if peak_value > crate::constants::PEAK_MODERATE_MIN {
-                                    // Moderate overshoot (16-20%) - graduated adjustment
-                                    (
-                                        "Moderate overshoot",
-                                        current_pd_ratio
-                                            * crate::constants::PEAK_MODERATE_MULTIPLIER,
-                                    )
-                                } else if peak_value > crate::constants::PEAK_ACCEPTABLE_MAX {
-                                    // Minor overshoot (11-15%) - smaller adjustment
-                                    (
-                                        "Minor overshoot",
-                                        current_pd_ratio * crate::constants::PEAK_MINOR_MULTIPLIER,
-                                    )
-                                } else if peak_value >= crate::constants::PEAK_ACCEPTABLE_MIN {
-                                    // Acceptable (5-10% overshoot) - minimal adjustment
-                                    (
-                                        "Acceptable response",
-                                        current_pd_ratio
-                                            * crate::constants::PEAK_ACCEPTABLE_MULTIPLIER,
-                                    )
-                                } else if peak_value >= crate::constants::PEAK_OPTIMAL_MIN {
-                                    // Optimal (0-5% overshoot/undershoot) - no change
-                                    ("Optimal response", current_pd_ratio)
-                                } else if peak_value >= 0.85 {
-                                    // Minor undershoot (6-15%) - small decrease
-                                    ("Minor undershoot", current_pd_ratio * 1.05)
-                                } else {
-                                    // Significant undershoot (>15%) - moderate decrease
-                                    ("Significant undershoot", current_pd_ratio * 1.15)
-                                };
+                                    } else if peak_value > crate::constants::PEAK_ACCEPTABLE_MAX {
+                                        (
+                                            "Overshoot",
+                                            current_pd_ratio
+                                                * crate::constants::PEAK_OVERSHOOT_MULTIPLIER,
+                                        )
+                                    } else if peak_value >= crate::constants::PEAK_ACCEPTABLE_MIN {
+                                        (
+                                            "Acceptable",
+                                            current_pd_ratio
+                                                * crate::constants::PEAK_ACCEPTABLE_MULTIPLIER,
+                                        )
+                                    } else if peak_value >= crate::constants::PEAK_OPTIMAL_MIN {
+                                        ("Optimal", current_pd_ratio)
+                                    } else if peak_value >= crate::constants::PEAK_UNDERSHOOT_MAX {
+                                        ("Near optimal", current_pd_ratio)
+                                    } else {
+                                        // Proportional D decrease: scale P:D toward the optimal sweet-spot centre
+                                        let multiplier = crate::constants::PEAK_OPTIMAL_TARGET
+                                            / peak_value.max(0.1);
+                                        ("Undershoot", current_pd_ratio * multiplier)
+                                    };
 
                                 // Store peak value, current P:D ratio, and assessment for plot legends
                                 peak_values[axis_index] = Some(peak_value);
@@ -730,10 +722,9 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                     recommended_pd_conservative[axis_index] =
                                         Some(recommended_ratio);
 
-                                    // Calculate moderate recommendation ONLY for moderate/significant overshoot (>1.15)
-                                    // For acceptable/minor overshoot (1.05-1.15), show conservative only
+                                    // Calculate moderate recommendation for any overshoot (>PEAK_ACCEPTABLE_MAX)
                                     let moderate_ratio =
-                                        if peak_value > crate::constants::PEAK_MINOR_MAX {
+                                        if peak_value > crate::constants::PEAK_ACCEPTABLE_MAX {
                                             let ratio = recommended_ratio
                                             * crate::constants::PD_RATIO_MODERATE_MULTIPLIER
                                             / crate::constants::PD_RATIO_CONSERVATIVE_MULTIPLIER;
@@ -802,6 +793,8 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
 
                                 if let Some(p_val) = axis_pid.p {
                                     println!("  Current P:D={current_pd_ratio:.2}");
+                                    // Needed in both branches below
+                                    let dmax_enabled = pid_metadata.is_dmax_enabled();
 
                                     // Show recommendations if they were computed (threshold exceeded)
                                     if recommended_pd_conservative[axis_index].is_some() {
@@ -832,9 +825,6 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                             println!("      Consider decreasing P or checking for overdamped response");
                                         }
 
-                                        // Check if D-Min/D-Max is enabled
-                                        let dmax_enabled = pid_metadata.is_dmax_enabled();
-
                                         // Show conservative recommendation
                                         if dmax_enabled
                                             && (recommended_d_min_conservative[axis_index]
@@ -849,7 +839,7 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                             let d_max_str = recommended_d_max_conservative
                                                 [axis_index]
                                                 .map_or("N/A".to_string(), |v| v.to_string());
-                                            println!("    Conservative: P:D={:.2} → D-Min≈{}, D-Max≈{} (P={})",
+                                            println!("  Recommendation (conservative): P:D={:.2} → D-Min≈{}, D-Max≈{} (P={})",
                                                 recommended_pd_conservative[axis_index].unwrap(),
                                                 d_min_str, d_max_str, p_val);
                                         } else if let Some(recommended_d) =
@@ -857,14 +847,21 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                         {
                                             // D-Min/D-Max disabled: show only base D
                                             println!(
-                                                "    Conservative: P:D={:.2} → D≈{} (P={})",
+                                                "  Recommendation (conservative): P:D={:.2} → D≈{} (P={})",
                                                 recommended_pd_conservative[axis_index].unwrap(),
                                                 recommended_d,
                                                 p_val
                                             );
                                         }
 
-                                        // Show moderate recommendation
+                                        // Show secondary (moderate/aggressive) recommendation
+                                        // Derive level: aggressive for significant overshoot, moderate otherwise
+                                        let secondary_level =
+                                            if assessment == "Significant overshoot" {
+                                                "aggressive"
+                                            } else {
+                                                "moderate"
+                                            };
                                         if dmax_enabled
                                             && (recommended_d_min_aggressive[axis_index].is_some()
                                                 || recommended_d_max_aggressive[axis_index]
@@ -877,7 +874,7 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                             let d_max_str = recommended_d_max_aggressive
                                                 [axis_index]
                                                 .map_or("N/A".to_string(), |v| v.to_string());
-                                            println!("    Moderate:     P:D={:.2} → D-Min≈{}, D-Max≈{} (P={})",
+                                            println!("  Recommendation ({secondary_level}): P:D={:.2} → D-Min≈{}, D-Max≈{} (P={})",
                                                 recommended_pd_aggressive[axis_index].unwrap(),
                                                 d_min_str, d_max_str, p_val);
                                         } else if let Some(recommended_d_mod) =
@@ -885,17 +882,41 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                         {
                                             // D-Min/D-Max disabled: show only base D
                                             println!(
-                                                "    Moderate:     P:D={:.2} → D≈{} (P={})",
+                                                "  Recommendation ({secondary_level}): P:D={:.2} → D≈{} (P={})",
                                                 recommended_pd_aggressive[axis_index].unwrap(),
                                                 recommended_d_mod,
                                                 p_val
                                             );
                                         }
                                     } else {
-                                        // No recommendations needed - response is already good
+                                        // Optimal or near-optimal zone — no P:D adjustment needed
                                         println!(
-                                            "  ({assessment} - no obvious tuning adjustments needed)"
+                                            "  Recommendation (none): No tuning adjustments needed"
                                         );
+                                        // Near optimal (1.00–1.02): suggest D-1 as optional fine-tune
+                                        if assessment == "Near optimal" {
+                                            if dmax_enabled {
+                                                let d_min_str = axis_pid
+                                                    .d_min
+                                                    .map(|v| v.saturating_sub(1))
+                                                    .map_or("N/A".to_string(), |v| v.to_string());
+                                                let d_max_str = axis_pid
+                                                    .d_max
+                                                    .or(axis_pid.d)
+                                                    .map(|v| v.saturating_sub(1))
+                                                    .map_or("N/A".to_string(), |v| v.to_string());
+                                                println!(
+                                                    "  Recommendation (conservative): D-Min≈{}, D-Max≈{} (P={}) [optional D−1]",
+                                                    d_min_str, d_max_str, p_val
+                                                );
+                                            } else if let Some(current_d) = axis_pid.d {
+                                                println!(
+                                                    "  Recommendation (conservative): D≈{} (P={}) [optional D−1]",
+                                                    current_d.saturating_sub(1),
+                                                    p_val
+                                                );
+                                            }
+                                        }
                                     }
                                 } else {
                                     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -678,45 +678,48 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                 //   PEAK_ACCEPTABLE_MIN..PEAK_ACCEPTABLE_MAX = acceptable: Recommendation (conservative)
                                 //   PEAK_ACCEPTABLE_MAX..PEAK_SIGNIFICANT_MIN = overshoot:  Recommendation (conservative)
                                 //   > PEAK_SIGNIFICANT_MIN       = significant:  conservative + moderate + aggressive
-                                let (assessment, recommended_ratio) =
-                                    if peak_value > crate::constants::PEAK_SIGNIFICANT_MIN {
-                                        (
+                                let (assessment, recommended_ratio) = if peak_value
+                                    > crate::constants::PEAK_SIGNIFICANT_MIN
+                                {
+                                    (
                                         "Significant overshoot",
                                         current_pd_ratio
                                             * crate::constants::PD_RATIO_CONSERVATIVE_MULTIPLIER,
                                     )
-                                    } else if peak_value > crate::constants::PEAK_ACCEPTABLE_MAX {
-                                        (
-                                            "Overshoot",
-                                            current_pd_ratio
-                                                * crate::constants::PEAK_OVERSHOOT_MULTIPLIER,
-                                        )
-                                    } else if peak_value >= crate::constants::PEAK_ACCEPTABLE_MIN {
-                                        (
-                                            "Acceptable",
-                                            current_pd_ratio
-                                                * crate::constants::PEAK_ACCEPTABLE_MULTIPLIER,
-                                        )
-                                    } else if peak_value >= crate::constants::PEAK_OPTIMAL_MIN {
-                                        ("Optimal", current_pd_ratio)
-                                    } else if peak_value >= crate::constants::PEAK_UNDERSHOOT_MAX {
-                                        ("Near optimal", current_pd_ratio)
-                                    } else {
-                                        // Proportional D decrease: scale P:D toward the optimal sweet-spot centre
-                                        let multiplier = crate::constants::PEAK_OPTIMAL_TARGET
-                                            / peak_value.max(0.1);
-                                        ("Undershoot", current_pd_ratio * multiplier)
-                                    };
+                                } else if peak_value > crate::constants::PEAK_ACCEPTABLE_MAX {
+                                    (
+                                        "Overshoot",
+                                        current_pd_ratio
+                                            * crate::constants::PEAK_OVERSHOOT_MULTIPLIER,
+                                    )
+                                } else if peak_value >= crate::constants::PEAK_ACCEPTABLE_MIN {
+                                    (
+                                        "Acceptable",
+                                        current_pd_ratio
+                                            * crate::constants::PEAK_ACCEPTABLE_MULTIPLIER,
+                                    )
+                                } else if peak_value >= crate::constants::PEAK_OPTIMAL_MIN {
+                                    ("Optimal", current_pd_ratio)
+                                } else if peak_value >= crate::constants::PEAK_UNDERSHOOT_MAX {
+                                    ("Near optimal", current_pd_ratio)
+                                } else {
+                                    // Proportional D decrease: scale P:D toward the optimal sweet-spot centre
+                                    let multiplier = crate::constants::PEAK_OPTIMAL_TARGET
+                                        / peak_value.max(crate::constants::PEAK_VALUE_MIN_CLAMP);
+                                    ("Undershoot", current_pd_ratio * multiplier)
+                                };
 
                                 // Store peak value, current P:D ratio, and assessment for plot legends
                                 peak_values[axis_index] = Some(peak_value);
                                 current_pd_ratios[axis_index] = Some(current_pd_ratio);
                                 assessments[axis_index] = Some(assessment);
 
-                                // Only store recommendations if change exceeds threshold
-                                // (to avoid showing recommendations for already-good responses)
-                                if (recommended_ratio - current_pd_ratio).abs()
-                                    > crate::constants::PD_RATIO_MIN_CHANGE_THRESHOLD
+                                // Always store recommendations for Acceptable zone (2% change never clears
+                                // the 5% threshold but the recommendation is still valid), otherwise
+                                // require a minimum change to avoid noise on already-good responses.
+                                if assessment == "Acceptable"
+                                    || (recommended_ratio - current_pd_ratio).abs()
+                                        > crate::constants::PD_RATIO_MIN_CHANGE_THRESHOLD
                                 {
                                     // store conservative recommendation for later use in plots
                                     recommended_pd_conservative[axis_index] =
@@ -854,14 +857,7 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                             );
                                         }
 
-                                        // Show secondary (moderate/aggressive) recommendation
-                                        // Derive level: aggressive for significant overshoot, moderate otherwise
-                                        let secondary_level =
-                                            if assessment == "Significant overshoot" {
-                                                "aggressive"
-                                            } else {
-                                                "moderate"
-                                            };
+                                        // Show secondary (moderate) recommendation
                                         if dmax_enabled
                                             && (recommended_d_min_aggressive[axis_index].is_some()
                                                 || recommended_d_max_aggressive[axis_index]
@@ -874,7 +870,7 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                             let d_max_str = recommended_d_max_aggressive
                                                 [axis_index]
                                                 .map_or("N/A".to_string(), |v| v.to_string());
-                                            println!("  Recommendation ({secondary_level}): P:D={:.2} → D-Min≈{}, D-Max≈{} (P={})",
+                                            println!("  Recommendation (moderate): P:D={:.2} → D-Min≈{}, D-Max≈{} (P={})",
                                                 recommended_pd_aggressive[axis_index].unwrap(),
                                                 d_min_str, d_max_str, p_val);
                                         } else if let Some(recommended_d_mod) =
@@ -882,11 +878,43 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                         {
                                             // D-Min/D-Max disabled: show only base D
                                             println!(
-                                                "  Recommendation ({secondary_level}): P:D={:.2} → D≈{} (P={})",
+                                                "  Recommendation (moderate): P:D={:.2} → D≈{} (P={})",
                                                 recommended_pd_aggressive[axis_index].unwrap(),
                                                 recommended_d_mod,
                                                 p_val
                                             );
+                                        }
+
+                                        // Show tertiary (aggressive) recommendation for significant overshoot only
+                                        if assessment == "Significant overshoot" {
+                                            let aggressive_pd = current_pd_ratio
+                                                * crate::constants::PD_RATIO_AGGRESSIVE_MULTIPLIER;
+                                            let (rec_d_agg, rec_d_min_agg, rec_d_max_agg) =
+                                                if axis_index == 0 {
+                                                    pid_metadata.roll.calculate_goal_d_with_range(
+                                                        aggressive_pd,
+                                                        dmax_enabled,
+                                                    )
+                                                } else {
+                                                    pid_metadata.pitch.calculate_goal_d_with_range(
+                                                        aggressive_pd,
+                                                        dmax_enabled,
+                                                    )
+                                                };
+                                            if dmax_enabled
+                                                && (rec_d_min_agg.is_some()
+                                                    || rec_d_max_agg.is_some())
+                                            {
+                                                let d_min_str = rec_d_min_agg
+                                                    .map_or("N/A".to_string(), |v| v.to_string());
+                                                let d_max_str = rec_d_max_agg
+                                                    .map_or("N/A".to_string(), |v| v.to_string());
+                                                println!("  Recommendation (aggressive): P:D={:.2} → D-Min≈{}, D-Max≈{} (P={})",
+                                                    aggressive_pd, d_min_str, d_max_str, p_val);
+                                            } else if let Some(rec_d3) = rec_d_agg {
+                                                println!("  Recommendation (aggressive): P:D={:.2} → D≈{} (P={})",
+                                                    aggressive_pd, rec_d3, p_val);
+                                            }
                                         }
                                     } else {
                                         // Optimal or near-optimal zone — no P:D adjustment needed
@@ -898,12 +926,20 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                             if dmax_enabled {
                                                 let d_min_str = axis_pid
                                                     .d_min
-                                                    .map(|v| v.saturating_sub(1))
+                                                    .map(|v| {
+                                                        v.saturating_sub(
+                                                            crate::constants::D_STEP_OPTIONAL,
+                                                        )
+                                                    })
                                                     .map_or("N/A".to_string(), |v| v.to_string());
                                                 let d_max_str = axis_pid
                                                     .d_max
                                                     .or(axis_pid.d)
-                                                    .map(|v| v.saturating_sub(1))
+                                                    .map(|v| {
+                                                        v.saturating_sub(
+                                                            crate::constants::D_STEP_OPTIONAL,
+                                                        )
+                                                    })
                                                     .map_or("N/A".to_string(), |v| v.to_string());
                                                 println!(
                                                     "  Recommendation (conservative): D-Min≈{}, D-Max≈{} (P={}) [optional D−1]",
@@ -912,7 +948,7 @@ INFO ({input_file_str}): Skipping Step Response input data filtering: {reason}."
                                             } else if let Some(current_d) = axis_pid.d {
                                                 println!(
                                                     "  Recommendation (conservative): D≈{} (P={}) [optional D−1]",
-                                                    current_d.saturating_sub(1),
+                                                    current_d.saturating_sub(crate::constants::D_STEP_OPTIONAL),
                                                     p_val
                                                 );
                                             }

--- a/src/plot_functions/plot_step_response.rs
+++ b/src/plot_functions/plot_step_response.rs
@@ -373,14 +373,17 @@ pub fn plot_step_response(
                         let d_max_str = recommended_d_max_conservative[axis_index]
                             .map_or("N/A".to_string(), |v| v.to_string());
                         format!(
-                            "Conservative: P:D={:.2} (D-Min≈{}, D-Max≈{})",
+                            "Recommendation (conservative): P:D={:.2} (D-Min≈{}, D-Max≈{})",
                             rec_pd, d_min_str, d_max_str
                         )
                     } else if let Some(rec_d) = recommended_d_conservative[axis_index] {
                         // D-Min/D-Max disabled: show only base D
-                        format!("Conservative: P:D={:.2} (D≈{})", rec_pd, rec_d)
+                        format!(
+                            "Recommendation (conservative): P:D={:.2} (D≈{})",
+                            rec_pd, rec_d
+                        )
                     } else {
-                        format!("Conservative: P:D={:.2}", rec_pd)
+                        format!("Recommendation (conservative): P:D={:.2}", rec_pd)
                     };
                     series.push(PlotSeries {
                         data: vec![],
@@ -388,9 +391,53 @@ pub fn plot_step_response(
                         color: RGBColor(100, 100, 100), // Medium gray for conservative
                         stroke_width: 0,                // Invisible legend line
                     });
+                } else {
+                    // Optimal or near-optimal — no P:D adjustment needed
+                    series.push(PlotSeries {
+                        data: vec![],
+                        label: "Recommendation (none): No obvious tuning adjustments needed"
+                            .to_string(),
+                        color: RGBColor(100, 100, 100),
+                        stroke_width: 0,
+                    });
+                    // Near optimal (1.00–1.02): suggest D-1 as an optional fine-tune
+                    if assessments[axis_index] == Some("Near optimal") {
+                        if let Some(axis_pid_data) = pid_metadata.get_axis(axis_index) {
+                            let d1_label = if dmax_enabled {
+                                let d_min_str = axis_pid_data
+                                    .d_min
+                                    .map(|v| v.saturating_sub(1))
+                                    .map_or("N/A".to_string(), |v| v.to_string());
+                                let d_max_str = axis_pid_data
+                                    .d_max
+                                    .or(axis_pid_data.d)
+                                    .map(|v| v.saturating_sub(1))
+                                    .map_or("N/A".to_string(), |v| v.to_string());
+                                format!(
+                                    "Recommendation (conservative): D-Min≈{}, D-Max≈{} [optional D−1]",
+                                    d_min_str, d_max_str
+                                )
+                            } else if let Some(current_d) = axis_pid_data.d {
+                                format!(
+                                    "Recommendation (conservative): D≈{} [optional D−1]",
+                                    current_d.saturating_sub(1)
+                                )
+                            } else {
+                                String::new()
+                            };
+                            if !d1_label.is_empty() {
+                                series.push(PlotSeries {
+                                    data: vec![],
+                                    label: d1_label,
+                                    color: RGBColor(100, 100, 100),
+                                    stroke_width: 0,
+                                });
+                            }
+                        }
+                    }
                 }
 
-                // Moderate recommendation
+                // Secondary recommendation (always moderate)
                 if let Some(rec_pd) = recommended_pd_aggressive[axis_index] {
                     let recommendation_label = if dmax_enabled {
                         // D-Min/D-Max enabled: show D-Min and D-Max, NOT base D
@@ -399,14 +446,14 @@ pub fn plot_step_response(
                         let d_max_str = recommended_d_max_aggressive[axis_index]
                             .map_or("N/A".to_string(), |v| v.to_string());
                         format!(
-                            "Moderate:     P:D={:.2} (D-Min≈{}, D-Max≈{})",
+                            "Recommendation (moderate): P:D={:.2} (D-Min≈{}, D-Max≈{})",
                             rec_pd, d_min_str, d_max_str
                         )
                     } else if let Some(rec_d) = recommended_d_aggressive[axis_index] {
                         // D-Min/D-Max disabled: show only base D
-                        format!("Moderate:     P:D={:.2} (D≈{})", rec_pd, rec_d)
+                        format!("Recommendation (moderate): P:D={:.2} (D≈{})", rec_pd, rec_d)
                     } else {
-                        format!("Moderate:     P:D={:.2}", rec_pd)
+                        format!("Recommendation (moderate): P:D={:.2}", rec_pd)
                     };
                     series.push(PlotSeries {
                         data: vec![],
@@ -414,6 +461,43 @@ pub fn plot_step_response(
                         color: RGBColor(70, 70, 70), // Darker gray for moderate
                         stroke_width: 0,             // Invisible legend line
                     });
+
+                    // Aggressive (third) recommendation for significant overshoot only
+                    if assessments[axis_index] == Some("Significant overshoot") {
+                        if let Some(current_pd) = current_pd_ratios[axis_index] {
+                            let aggressive_pd =
+                                current_pd * crate::constants::PD_RATIO_AGGRESSIVE_MULTIPLIER;
+                            if let Some(axis_pid_data) = pid_metadata.get_axis(axis_index) {
+                                let (rec_d_agg, rec_d_min_agg, rec_d_max_agg) = axis_pid_data
+                                    .calculate_goal_d_with_range(aggressive_pd, dmax_enabled);
+                                let agg_label = if dmax_enabled
+                                    && (rec_d_min_agg.is_some() || rec_d_max_agg.is_some())
+                                {
+                                    let d_min_str =
+                                        rec_d_min_agg.map_or("N/A".to_string(), |v| v.to_string());
+                                    let d_max_str =
+                                        rec_d_max_agg.map_or("N/A".to_string(), |v| v.to_string());
+                                    format!(
+                                        "Recommendation (aggressive): P:D={:.2} (D-Min≈{}, D-Max≈{})",
+                                        aggressive_pd, d_min_str, d_max_str
+                                    )
+                                } else if let Some(rec_d3) = rec_d_agg {
+                                    format!(
+                                        "Recommendation (aggressive): P:D={:.2} (D≈{})",
+                                        aggressive_pd, rec_d3
+                                    )
+                                } else {
+                                    format!("Recommendation (aggressive): P:D={:.2}", aggressive_pd)
+                                };
+                                series.push(PlotSeries {
+                                    data: vec![],
+                                    label: agg_label,
+                                    color: RGBColor(50, 50, 50), // Darkest gray for aggressive
+                                    stroke_width: 0,
+                                });
+                            }
+                        }
+                    }
                 }
             }
 

--- a/src/plot_functions/plot_step_response.rs
+++ b/src/plot_functions/plot_step_response.rs
@@ -391,8 +391,42 @@ pub fn plot_step_response(
                         color: RGBColor(100, 100, 100), // Medium gray for conservative
                         stroke_width: 0,                // Invisible legend line
                     });
+                } else if assessments[axis_index] == Some("Near optimal") {
+                    // Near optimal (1.00–1.02): D−1 hint replaces the "none" label —
+                    // showing "none" and a concrete suggestion together is contradictory.
+                    if let Some(axis_pid_data) = pid_metadata.get_axis(axis_index) {
+                        let d1_label = if dmax_enabled {
+                            let d_min_str = axis_pid_data
+                                .d_min
+                                .map(|v| v.saturating_sub(crate::constants::D_STEP_OPTIONAL))
+                                .map_or("N/A".to_string(), |v| v.to_string());
+                            let d_max_str = axis_pid_data
+                                .d_max
+                                .or(axis_pid_data.d)
+                                .map(|v| v.saturating_sub(crate::constants::D_STEP_OPTIONAL))
+                                .map_or("N/A".to_string(), |v| v.to_string());
+                            format!(
+                                "Recommendation (conservative): D-Min≈{}, D-Max≈{} [optional D−1]",
+                                d_min_str, d_max_str
+                            )
+                        } else if let Some(current_d) = axis_pid_data.d {
+                            format!(
+                                "Recommendation (conservative): D≈{} [optional D−1]",
+                                current_d.saturating_sub(crate::constants::D_STEP_OPTIONAL)
+                            )
+                        } else {
+                            "Recommendation (none): No obvious tuning adjustments needed"
+                                .to_string()
+                        };
+                        series.push(PlotSeries {
+                            data: vec![],
+                            label: d1_label,
+                            color: RGBColor(100, 100, 100),
+                            stroke_width: 0,
+                        });
+                    }
                 } else {
-                    // Optimal or near-optimal — no P:D adjustment needed
+                    // Optimal zone (1.02–1.08): no adjustment needed
                     series.push(PlotSeries {
                         data: vec![],
                         label: "Recommendation (none): No obvious tuning adjustments needed"
@@ -400,41 +434,6 @@ pub fn plot_step_response(
                         color: RGBColor(100, 100, 100),
                         stroke_width: 0,
                     });
-                    // Near optimal (1.00–1.02): suggest D-1 as an optional fine-tune
-                    if assessments[axis_index] == Some("Near optimal") {
-                        if let Some(axis_pid_data) = pid_metadata.get_axis(axis_index) {
-                            let d1_label = if dmax_enabled {
-                                let d_min_str = axis_pid_data
-                                    .d_min
-                                    .map(|v| v.saturating_sub(1))
-                                    .map_or("N/A".to_string(), |v| v.to_string());
-                                let d_max_str = axis_pid_data
-                                    .d_max
-                                    .or(axis_pid_data.d)
-                                    .map(|v| v.saturating_sub(1))
-                                    .map_or("N/A".to_string(), |v| v.to_string());
-                                format!(
-                                    "Recommendation (conservative): D-Min≈{}, D-Max≈{} [optional D−1]",
-                                    d_min_str, d_max_str
-                                )
-                            } else if let Some(current_d) = axis_pid_data.d {
-                                format!(
-                                    "Recommendation (conservative): D≈{} [optional D−1]",
-                                    current_d.saturating_sub(1)
-                                )
-                            } else {
-                                String::new()
-                            };
-                            if !d1_label.is_empty() {
-                                series.push(PlotSeries {
-                                    data: vec![],
-                                    label: d1_label,
-                                    color: RGBColor(100, 100, 100),
-                                    stroke_width: 0,
-                                });
-                            }
-                        }
-                    }
                 }
 
                 // Secondary recommendation (always moderate)


### PR DESCRIPTION
AI Generated pull-request

---

binaries here: https://github.com/nerdCopter/BlackBox_CSV_Render/actions/runs/26182899097

---

## Summary

Reworked step-response tuning zones and recommendation strategy to align with real-world practical aircraft tuning rather than theoretical control theory. This change collapses 7 overly-granular zones into 6 honest zones, implements proportional undershoot correction, and standardizes recommendation labels across console and PNG outputs.

## Motivation

Per practical-vs-theoretical.md: real aircraft PID tuning must acknowledge that:

- **Zero-overshoot response indicates P is undertuned.** Classical control theory (critically damped, no overshoot) is unachievable on real hardware due to motor lag, ESC latency, prop flex, and gyro noise.
- **The correct goal** is controlled overshoot: maximize P until single clean overshoot appears, then tune D to damp it in one arc with no ringing.
- **False precision wastes effort.** 1.12–1.15 vs 1.15–1.20 distinction adds no practical value when measurement noise is ±3–5%.

Per Proposed Best Tuning Thresholds.md: the sweet spot is 1.02–1.08 (Pro Sweet Spot), where the response has momentum and feel, with graduated recommendations for acceptable and overshoot zones.

## Changes

### Constants (src/constants.rs)
- Simplify zones: remove PEAK_MINOR_MIN/MAX, PEAK_MODERATE_MIN/MAX sub-boundaries
- Add PEAK_OPTIMAL_TARGET = 1.05 (centre of sweet spot) for proportional undershoot aim-point
- Add PEAK_OVERSHOOT_MULTIPLIER (0.92) for unified 1.12–1.20 zone
- Add PD_RATIO_AGGRESSIVE_MULTIPLIER (0.65) for significant overshoot (>1.20)
- Net: 3 dead-code markers in constants.rs (down from 5 in master)

### Zone structure (6 zones)
1. **< 1.00 Undershoot:** proportional D decrease: P:D × (1.05 / peak) — targets sweet-spot centre, replaces flat multiplier
2. **1.00–1.02 Near optimal:** Recommendation (none) + optional D−1 hint
3. **1.02–1.08 Optimal:** Recommendation (none) — the Pro Sweet Spot
4. **1.08–1.12 Acceptable:** Recommendation (conservative): +≈2% D
5. **1.12–1.20 Overshoot:** Recommendation (conservative) + (moderate) — both recommendations stacked
6. **> 1.20 Significant:** Recommendation (conservative) + (moderate) + (aggressive) — all three

### Recommendation output (src/main.rs, src/plot_functions/plot_step_response.rs)
- Standardized label format: "Recommendation (none|conservative|moderate|aggressive):"
- Applied consistently to console output and PNG legend entries
- Secondary (moderate) now triggers at PEAK_ACCEPTABLE_MAX (1.12) instead of only at PEAK_SIGNIFICANT_MIN (1.20), giving overshoot zones two graduated options
- Tertiary (aggressive) only for peak > 1.20

## Testing
- ✅ All 212 input CSVs process with zero failures (OK=212 FAIL=0)
- ✅ 106 valid PNG plots generated
- ✅ Clippy: zero warnings/errors
- ✅ Cargo fmt: clean
- ✅ Pre-commit hook: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added aggressive P:D ratio tuning multiplier
  * Introduced refined peak response classification zones
  * Enhanced undershoot adjustment calculations

* **Improvements**
  * Updated step-response recommendation labels for clarity
  * Improved tuning suggestion legend formatting and organization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nerdCopter/BlackBox_CSV_Render/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->