### PR TITLE
fix: clear Reliable/Unreliable consistency label with both metrics (fixes #149)

### DIFF
--- a/src/data_analysis/optimal_p_estimation.rs
+++ b/src/data_analysis/optimal_p_estimation.rs
@@ -513,17 +513,41 @@ impl OptimalPAnalysis {
             self.td_stats.consistency * 100.0
         ));
 
-        // Warning for low consistency (inline)
+        // Warning for low consistency (inline) — report only the condition(s) that actually failed
         if !self.td_stats.is_consistent() {
-            let cv_percent = self
+            let cv_failed = self
                 .td_stats
                 .coefficient_of_variation
-                .map_or(0.0, |cv| cv * 100.0);
-            output.push_str(&format!(
-                "  ⚠ Low consistency (CV={:.1}%) — unreliable (>{:.0}%)\n",
-                cv_percent,
-                TD_COEFFICIENT_OF_VARIATION_MAX * 100.0
-            ));
+                .is_some_and(|cv| cv > TD_COEFFICIENT_OF_VARIATION_MAX);
+            let consistency_failed = self.td_stats.consistency < TD_CONSISTENCY_MIN_THRESHOLD;
+            let reason = match (cv_failed, consistency_failed) {
+                (true, true) => format!(
+                    "CV={:.1}% (>{:.0}%) and Consistency={:.0}% (<{:.0}%)",
+                    self.td_stats
+                        .coefficient_of_variation
+                        .map_or(0.0, |cv| cv * 100.0),
+                    TD_COEFFICIENT_OF_VARIATION_MAX * 100.0,
+                    self.td_stats.consistency * 100.0,
+                    TD_CONSISTENCY_MIN_THRESHOLD * 100.0,
+                ),
+                (true, false) => format!(
+                    "CV={:.1}% (>{:.0}%)",
+                    self.td_stats
+                        .coefficient_of_variation
+                        .map_or(0.0, |cv| cv * 100.0),
+                    TD_COEFFICIENT_OF_VARIATION_MAX * 100.0,
+                ),
+                (false, true) => format!(
+                    "Consistency={:.0}% (<{:.0}%)",
+                    self.td_stats.consistency * 100.0,
+                    TD_CONSISTENCY_MIN_THRESHOLD * 100.0,
+                ),
+                (false, false) => format!(
+                    "insufficient samples (need >= {})",
+                    TD_SAMPLES_MIN_FOR_STDDEV,
+                ),
+            };
+            output.push_str(&format!("  ⚠ Low consistency ({reason}) — unreliable\n"));
         }
 
         // Compact recommendation

--- a/src/data_analysis/optimal_p_estimation.rs
+++ b/src/data_analysis/optimal_p_estimation.rs
@@ -503,51 +503,37 @@ impl OptimalPAnalysis {
 
         // Compact header - axis name and basic info
         output.push_str(&format!(
-            "{}: Td={:.1}ms (target {}, {:+.0}% dev, windows={}), Noise={}, Consistency={:.0}%\n",
+            "{}: Td={:.1}ms (target {}, {:+.0}% dev, windows={}), Noise={}\n",
             axis_name,
             self.td_stats.mean_ms,
             target_display,
             self.td_deviation_percent,
             self.td_stats.num_samples,
             self.noise_level.name(),
-            self.td_stats.consistency * 100.0
         ));
 
-        // Warning for low consistency (inline) — report only the condition(s) that actually failed
-        if !self.td_stats.is_consistent() {
-            let cv_failed = self
-                .td_stats
-                .coefficient_of_variation
-                .is_some_and(|cv| cv > TD_COEFFICIENT_OF_VARIATION_MAX);
-            let consistency_failed = self.td_stats.consistency < TD_CONSISTENCY_MIN_THRESHOLD;
-            let reason = match (cv_failed, consistency_failed) {
-                (true, true) => format!(
-                    "CV={:.1}% (>{:.0}%) and Consistency={:.0}% (<{:.0}%)",
-                    self.td_stats
-                        .coefficient_of_variation
-                        .map_or(0.0, |cv| cv * 100.0),
-                    TD_COEFFICIENT_OF_VARIATION_MAX * 100.0,
-                    self.td_stats.consistency * 100.0,
-                    TD_CONSISTENCY_MIN_THRESHOLD * 100.0,
-                ),
-                (true, false) => format!(
-                    "CV={:.1}% (>{:.0}%)",
-                    self.td_stats
-                        .coefficient_of_variation
-                        .map_or(0.0, |cv| cv * 100.0),
-                    TD_COEFFICIENT_OF_VARIATION_MAX * 100.0,
-                ),
-                (false, true) => format!(
-                    "Consistency={:.0}% (<{:.0}%)",
-                    self.td_stats.consistency * 100.0,
-                    TD_CONSISTENCY_MIN_THRESHOLD * 100.0,
-                ),
-                (false, false) => format!(
-                    "insufficient samples (need >= {})",
-                    TD_SAMPLES_MIN_FOR_STDDEV,
-                ),
-            };
-            output.push_str(&format!("  ⚠ Low consistency ({reason}) — unreliable\n"));
+        // Reliability line — always shown with both metrics
+        {
+            let cv_str = self.td_stats.coefficient_of_variation.map_or_else(
+                || "CV=N/A".to_string(),
+                |cv| {
+                    format!(
+                        "CV={:.1}% (≤{:.0}%)",
+                        cv * 100.0,
+                        TD_COEFFICIENT_OF_VARIATION_MAX * 100.0,
+                    )
+                },
+            );
+            let cons_str = format!(
+                "Consistency={:.0}% (≥{:.0}%)",
+                self.td_stats.consistency * 100.0,
+                TD_CONSISTENCY_MIN_THRESHOLD * 100.0,
+            );
+            if self.td_stats.is_consistent() {
+                output.push_str(&format!("  Reliable: {cons_str}, {cv_str}\n"));
+            } else {
+                output.push_str(&format!("  Unreliable: {cons_str}, {cv_str}\n"));
+            }
         }
 
         // Compact recommendation

--- a/src/plot_functions/plot_step_response.rs
+++ b/src/plot_functions/plot_step_response.rs
@@ -12,6 +12,7 @@ use crate::constants::{
     FINAL_NORMALIZED_STEADY_STATE_TOLERANCE, LINE_WIDTH_PLOT,
     LOW_AUTHORITY_SETPOINT_THRESHOLD_DEG_S, POST_AVERAGING_SMOOTHING_WINDOW, RESPONSE_LENGTH_S,
     STEADY_STATE_END_S, STEADY_STATE_START_S, TD_COEFFICIENT_OF_VARIATION_MAX,
+    TD_CONSISTENCY_MIN_THRESHOLD, TD_SAMPLES_MIN_FOR_STDDEV,
 };
 use crate::data_analysis::calc_step_response; // For average_responses and moving_average_smooth_f64
 use crate::data_analysis::optimal_p_estimation::{OptimalPAnalysis, PRecommendation};
@@ -631,19 +632,48 @@ pub fn plot_step_response(
 
                         // Consistency — always shown; orange warning when poor
                         {
-                            let cv_percent = analysis
-                                .td_stats
-                                .coefficient_of_variation
-                                .map_or(0.0, |cv| cv * 100.0);
                             let consistency_pct =
                                 (analysis.td_stats.consistency * 100.0).round() as u32;
                             let (cons_label, cons_color) = if !analysis.td_stats.is_consistent() {
+                                let cv_failed = analysis
+                                    .td_stats
+                                    .coefficient_of_variation
+                                    .is_some_and(|cv| cv > TD_COEFFICIENT_OF_VARIATION_MAX);
+                                let consistency_failed =
+                                    analysis.td_stats.consistency < TD_CONSISTENCY_MIN_THRESHOLD;
+                                let reason = match (cv_failed, consistency_failed) {
+                                    (true, true) => format!(
+                                        "CV={:.1}% (>{:.0}%) and Consistency={:.0}% (<{:.0}%)",
+                                        analysis
+                                            .td_stats
+                                            .coefficient_of_variation
+                                            .map_or(0.0, |cv| cv * 100.0),
+                                        TD_COEFFICIENT_OF_VARIATION_MAX * 100.0,
+                                        analysis.td_stats.consistency * 100.0,
+                                        TD_CONSISTENCY_MIN_THRESHOLD * 100.0,
+                                    ),
+                                    (true, false) => format!(
+                                        "CV={:.1}% (>{:.0}%)",
+                                        analysis
+                                            .td_stats
+                                            .coefficient_of_variation
+                                            .map_or(0.0, |cv| cv * 100.0),
+                                        TD_COEFFICIENT_OF_VARIATION_MAX * 100.0,
+                                    ),
+                                    (false, true) => format!(
+                                        "Consistency={:.0}% (<{:.0}%)",
+                                        analysis.td_stats.consistency * 100.0,
+                                        TD_CONSISTENCY_MIN_THRESHOLD * 100.0,
+                                    ),
+                                    (false, false) => format!(
+                                        "insufficient samples (need >= {})",
+                                        TD_SAMPLES_MIN_FOR_STDDEV,
+                                    ),
+                                };
                                 (
                                     format!(
-                                        "  Consistency: {}% (CV={:.1}%) — unreliable (>{:.0}%)",
-                                        consistency_pct,
-                                        cv_percent,
-                                        TD_COEFFICIENT_OF_VARIATION_MAX * 100.0
+                                        "  Consistency: {}% — unreliable ({})",
+                                        consistency_pct, reason
                                     ),
                                     COLOR_OPTIMAL_P_WARNING,
                                 )

--- a/src/plot_functions/plot_step_response.rs
+++ b/src/plot_functions/plot_step_response.rs
@@ -12,7 +12,7 @@ use crate::constants::{
     FINAL_NORMALIZED_STEADY_STATE_TOLERANCE, LINE_WIDTH_PLOT,
     LOW_AUTHORITY_SETPOINT_THRESHOLD_DEG_S, POST_AVERAGING_SMOOTHING_WINDOW, RESPONSE_LENGTH_S,
     STEADY_STATE_END_S, STEADY_STATE_START_S, TD_COEFFICIENT_OF_VARIATION_MAX,
-    TD_CONSISTENCY_MIN_THRESHOLD, TD_SAMPLES_MIN_FOR_STDDEV,
+    TD_CONSISTENCY_MIN_THRESHOLD,
 };
 use crate::data_analysis::calc_step_response; // For average_responses and moving_average_smooth_f64
 use crate::data_analysis::optimal_p_estimation::{OptimalPAnalysis, PRecommendation};
@@ -630,57 +630,32 @@ pub fn plot_step_response(
                             stroke_width: 0,
                         });
 
-                        // Consistency — always shown; orange warning when poor
+                        // Reliability — always shown with both metrics; orange when poor
                         {
-                            let consistency_pct =
-                                (analysis.td_stats.consistency * 100.0).round() as u32;
-                            let (cons_label, cons_color) = if !analysis.td_stats.is_consistent() {
-                                let cv_failed = analysis
-                                    .td_stats
-                                    .coefficient_of_variation
-                                    .is_some_and(|cv| cv > TD_COEFFICIENT_OF_VARIATION_MAX);
-                                let consistency_failed =
-                                    analysis.td_stats.consistency < TD_CONSISTENCY_MIN_THRESHOLD;
-                                let reason = match (cv_failed, consistency_failed) {
-                                    (true, true) => format!(
-                                        "CV={:.1}% (>{:.0}%) and Consistency={:.0}% (<{:.0}%)",
-                                        analysis
-                                            .td_stats
-                                            .coefficient_of_variation
-                                            .map_or(0.0, |cv| cv * 100.0),
-                                        TD_COEFFICIENT_OF_VARIATION_MAX * 100.0,
-                                        analysis.td_stats.consistency * 100.0,
-                                        TD_CONSISTENCY_MIN_THRESHOLD * 100.0,
-                                    ),
-                                    (true, false) => format!(
-                                        "CV={:.1}% (>{:.0}%)",
-                                        analysis
-                                            .td_stats
-                                            .coefficient_of_variation
-                                            .map_or(0.0, |cv| cv * 100.0),
-                                        TD_COEFFICIENT_OF_VARIATION_MAX * 100.0,
-                                    ),
-                                    (false, true) => format!(
-                                        "Consistency={:.0}% (<{:.0}%)",
-                                        analysis.td_stats.consistency * 100.0,
-                                        TD_CONSISTENCY_MIN_THRESHOLD * 100.0,
-                                    ),
-                                    (false, false) => format!(
-                                        "insufficient samples (need >= {})",
-                                        TD_SAMPLES_MIN_FOR_STDDEV,
-                                    ),
-                                };
-                                (
+                            let cv_str = analysis.td_stats.coefficient_of_variation.map_or_else(
+                                || "CV=N/A".to_string(),
+                                |cv| {
                                     format!(
-                                        "  Consistency: {}% — unreliable ({})",
-                                        consistency_pct, reason
-                                    ),
-                                    COLOR_OPTIMAL_P_WARNING,
+                                        "CV={:.1}% (≤{:.0}%)",
+                                        cv * 100.0,
+                                        TD_COEFFICIENT_OF_VARIATION_MAX * 100.0,
+                                    )
+                                },
+                            );
+                            let cons_str = format!(
+                                "Consistency={:.0}% (≥{:.0}%)",
+                                analysis.td_stats.consistency * 100.0,
+                                TD_CONSISTENCY_MIN_THRESHOLD * 100.0,
+                            );
+                            let (cons_label, cons_color) = if analysis.td_stats.is_consistent() {
+                                (
+                                    format!("  Reliable: {cons_str}, {cv_str}"),
+                                    COLOR_OPTIMAL_P_TEXT,
                                 )
                             } else {
                                 (
-                                    format!("  Consistency: {}%", consistency_pct),
-                                    COLOR_OPTIMAL_P_TEXT,
+                                    format!("  Unreliable: {cons_str}, {cv_str}"),
+                                    COLOR_OPTIMAL_P_WARNING,
                                 )
                             };
                             series.push(PlotSeries {


### PR DESCRIPTION
**Artifacts:** https://github.com/nerdCopter/BlackBox_CSV_Render/actions/runs/26253231908

---

Fixes #149 — the consistency warning in Optimal P Estimation always blamed `CV>40%` even when the actual failure was `Consistency<70%`, causing confusing messages like `CV=31.9% — unreliable (>40%)`.

- **Both metrics always shown** — `Reliable`/`Unreliable` label followed by `Consistency=XX% (≥70%), CV=XX% (≤40%)`, regardless of which condition failed
- **Unambiguous threshold notation** — `≥/≤` makes the pass/fail direction self-evident for both metrics
- **`CV=N/A`** when insufficient samples (`coefficient_of_variation` is `None`)
- **Consistent across console and PNG** — same verbiage in both outputs, same color logic (orange when unreliable)
- **Removes `Consistency=XX%` from the compact header line** — no longer duplicated
- **No warning icon** — plain `Reliable:` / `Unreliable:` prefix, consistent in both states

### Before
```
Roll: Td=22ms (target ...), Noise=LOW, Consistency=69%
  ⚠ Low consistency (Consistency=69% (<70%)) — unreliable
```

### After
```
Roll: Td=22ms (target ...), Noise=LOW
  Unreliable: Consistency=69% (≥70%), CV=31.9% (≤40%)
```

## Test plan

- [x] Clippy clean, `cargo fmt` applied
- [x] Ran all 18 `./input/*HELIO*` files with `--step --estimate-optimal-p`
- [x] All three failure modes exercised across test files:
  - Consistency-only: `20260103_160240.01` Roll — `Consistency=69% (≥70%), CV=31.9% (≤40%)`
  - CV-only: `20260503_140158_master.01` Roll — `Consistency=90% (≥70%), CV=90.1% (≤40%)`
  - Both: `20260503_112224_PR1139_hover-test` Roll — `Consistency=54% (≥70%), CV=49.3% (≤40%)`
- [x] All 18 PNGs generated without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)