### PR TITLE
refactor: core-only default output with --extended, --step, --bode CLI

### DIFF
--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -23,7 +23,7 @@ All analysis parameters, thresholds, plot dimensions, and algorithmic constants 
 ### Core Functionality
 
 1.  **Argument Parsing (`src/main.rs`):**
-    * Parses command-line arguments: input CSV file(s), an optional `--dps` parameter (requires a numeric threshold value for detailed step response plots with low/high split), an optional `--output-dir` for specifying the output directory, and plot-selection flags (`--core` [default], `--extended`, `--step`, `--motor`, `--spectrums`, `--tracking`, `--gyro-filt`, `--setpoint`, `--pid`, `--psd`, `--heatmaps`, `--bode`).
+    * Parses command-line arguments: input CSV file(s), an optional `--dps` parameter (requires a numeric threshold value for detailed step response plots with low/high split), an optional `--output-dir` for specifying the output directory, and plot-selection flags (`--core` [default], `--extended`, `--step`, `--motor`, `--spectrums`, `--tracking`, `--gyro-filt`, `--pid`, `--psd`, `--heatmaps`, `--bode`).
     * Additional options include `--help` and `--version` for user assistance.
     * The `--output-dir` parameter now requires a directory path when specified. If omitted, plots are saved in the source folder (input file's directory).
     * Handles multiple input files and determines if a directory prefix should be added to output filenames to avoid collisions when processing files from different directories.
@@ -101,7 +101,7 @@ All analysis parameters, thresholds, plot dimensions, and algorithmic constants 
                 * **Extended plots (`--extended` or individual flags):**
                     * `plot_pidsum_error_setpoint`: PIDsum (P+I+D), PID Error (Setpoint - GyroADC), and Setpoint time-domain traces for each axis. (`--pid`)
                     * `plot_pid_activity`: P, I, D term activity over time. (`--pid`)
-                    * `plot_setpoint_derivative`: Setpoint rate-of-change (feed-forward proxy) for each axis. (`--setpoint`)
+                    * `plot_setpoint_derivative`: Setpoint rate-of-change (feed-forward proxy) for each axis. (`--pid`)
                     * `plot_psd`: Power Spectral Density plots in dB scale with peak labeling. Includes enhanced cross-correlation filtering delay calculation. (`--psd`)
                     * `plot_d_term_psd`: Power Spectral Density plots of D-term data in dB scale with intelligent threshold filtering (`PSD_PEAK_LABEL_MIN_VALUE_DB` for filtered data) and enhanced formatting. Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0). (`--psd`)
                     * `plot_d_term_heatmap`: D-term throttle-frequency heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze D-term energy distribution across different throttle levels. (`--heatmaps`)

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -23,7 +23,7 @@ All analysis parameters, thresholds, plot dimensions, and algorithmic constants 
 ### Core Functionality
 
 1.  **Argument Parsing (`src/main.rs`):**
-    * Parses command-line arguments: input CSV file(s), an optional `--dps` parameter (requires a numeric threshold value for detailed step response plots with low/high split), an optional `--output-dir` for specifying the output directory, and an optional `--step` flag to generate only step response plots.
+    * Parses command-line arguments: input CSV file(s), an optional `--dps` parameter (requires a numeric threshold value for detailed step response plots with low/high split), an optional `--output-dir` for specifying the output directory, and plot-selection flags (`--core` [default], `--extended`, `--step`, `--motor`, `--spectrums`, `--tracking`, `--gyro-filt`, `--setpoint`, `--pid`, `--psd`, `--heatmaps`, `--bode`).
     * Additional options include `--help` and `--version` for user assistance.
     * The `--output-dir` parameter now requires a directory path when specified. If omitted, plots are saved in the source folder (input file's directory).
     * Handles multiple input files and determines if a directory prefix should be added to output filenames to avoid collisions when processing files from different directories.
@@ -91,17 +91,22 @@ All analysis parameters, thresholds, plot dimensions, and algorithmic constants 
                     * Clear disclaimers that recommendations are starting points, not absolute values
                     * Works for all aircraft sizes including 10"+ where D > P (P:D < 1.0)
                 * Recommendations appear in both console output and step response plot legends
-            * **Other plots generated (`src/plot_functions/`):** When the `--step` flag is not used, the following additional plots are generated. These per-plot gates are controlled by the `PlotConfig` struct (defaults to all enabled; `PlotConfig::step_only()` when `--step` is specified):
-                * `plot_pidsum_error_setpoint`: PIDsum (P+I+D), PID Error (Setpoint - GyroADC), and Setpoint time-domain traces for each axis.
-                * `plot_setpoint_vs_gyro`: Setpoint and filtered gyro time-domain comparison for each axis.
-                * `plot_gyro_vs_unfilt`: Filtered vs. unfiltered gyro time-domain comparison for each axis. Includes enhanced cross-correlation filtering delay calculation.
-                * `plot_gyro_spectrums`: Frequency-domain amplitude spectrums of filtered and unfiltered gyro data with intelligent peak detection and labeling using scale-aware thresholds (`FILTERED_GYRO_MIN_THRESHOLD` for filtered gyro data). Includes enhanced cross-correlation filtering delay calculation and flight firmware filter response curve overlays.
-                * `plot_psd`: Power Spectral Density plots in dB scale with peak labeling. Includes enhanced cross-correlation filtering delay calculation.
-                * `plot_d_term_spectrums`: Frequency-domain amplitude spectrums of D-term data with intelligent peak detection using scale-aware thresholds (`FILTERED_D_TERM_MIN_THRESHOLD` for filtered D-term data). Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0).
-                * `plot_d_term_psd`: Power Spectral Density plots of D-term data in dB scale with intelligent threshold filtering (`PSD_PEAK_LABEL_MIN_VALUE_DB` for filtered data) and enhanced formatting. Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0).
-                * `plot_d_term_heatmap`: D-term throttle-frequency heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze D-term energy distribution across different throttle levels.
-                * `plot_psd_db_heatmap`: Spectrograms showing PSD vs. time as heatmaps using Short-Time Fourier Transform (STFT) with configurable window duration and overlap.
-                * `plot_throttle_freq_heatmap`: Heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze noise characteristics across different throttle levels.
+            * **Other plots generated (`src/plot_functions/`):** Which plots are generated is controlled by the `PlotConfig` struct. The default (`--core`) enables the core set; `--extended` enables all plots except Bode; individual flags enable specific subsets. Plots are gated per-field in `PlotConfig`:
+                * **Core plots (default):**
+                    * `plot_setpoint_vs_gyro`: Setpoint and filtered gyro time-domain comparison for each axis.
+                    * `plot_gyro_vs_unfilt`: Filtered vs. unfiltered gyro time-domain comparison for each axis. Includes enhanced cross-correlation filtering delay calculation.
+                    * `plot_gyro_spectrums`: Frequency-domain amplitude spectrums of filtered and unfiltered gyro data with intelligent peak detection and labeling using scale-aware thresholds (`FILTERED_GYRO_MIN_THRESHOLD` for filtered gyro data). Includes enhanced cross-correlation filtering delay calculation and flight firmware filter response curve overlays.
+                    * `plot_d_term_spectrums`: Frequency-domain amplitude spectrums of D-term data with intelligent peak detection using scale-aware thresholds (`FILTERED_D_TERM_MIN_THRESHOLD` for filtered D-term data). Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0).
+                    * `plot_motor_spectrums`: Motor output frequency analysis.
+                * **Extended plots (`--extended` or individual flags):**
+                    * `plot_pidsum_error_setpoint`: PIDsum (P+I+D), PID Error (Setpoint - GyroADC), and Setpoint time-domain traces for each axis. (`--pid`)
+                    * `plot_pid_activity`: P, I, D term activity over time. (`--pid`)
+                    * `plot_setpoint_derivative`: Setpoint rate-of-change (feed-forward proxy) for each axis. (`--setpoint`)
+                    * `plot_psd`: Power Spectral Density plots in dB scale with peak labeling. Includes enhanced cross-correlation filtering delay calculation. (`--psd`)
+                    * `plot_d_term_psd`: Power Spectral Density plots of D-term data in dB scale with intelligent threshold filtering (`PSD_PEAK_LABEL_MIN_VALUE_DB` for filtered data) and enhanced formatting. Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0). (`--psd`)
+                    * `plot_d_term_heatmap`: D-term throttle-frequency heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze D-term energy distribution across different throttle levels. (`--heatmaps`)
+                    * `plot_psd_db_heatmap`: Spectrograms showing PSD vs. time as heatmaps using Short-Time Fourier Transform (STFT) with configurable window duration and overlap. (`--heatmaps`)
+                    * `plot_throttle_freq_heatmap`: Heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze noise characteristics across different throttle levels. (`--heatmaps`)
 
 ### Filtering Delay Calculation
 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -23,7 +23,7 @@ All analysis parameters, thresholds, plot dimensions, and algorithmic constants 
 ### Core Functionality
 
 1.  **Argument Parsing (`src/main.rs`):**
-    * Parses command-line arguments: input CSV file(s), an optional `--dps` parameter (requires a numeric threshold value for detailed step response plots with low/high split), an optional `--output-dir` for specifying the output directory, and plot-selection flags (`--core` [default], `--extended`, `--step`, `--motor`, `--spectrums`, `--tracking`, `--gyro-filt`, `--setpoint`, `--pid`, `--psd`, `--heatmaps`, `--bode`).
+    * Parses command-line arguments: input CSV file(s), an optional `--dps` parameter (requires a numeric threshold value for detailed step response plots with low/high split), an optional `--output-dir` for specifying the output directory, and plot-selection flags (`--extended`, `--step`, `--bode`). Default with no plot flag generates core plots.
     * Additional options include `--help` and `--version` for user assistance.
     * The `--output-dir` parameter now requires a directory path when specified. If omitted, plots are saved in the source folder (input file's directory).
     * Handles multiple input files and determines if a directory prefix should be added to output filenames to avoid collisions when processing files from different directories.
@@ -91,22 +91,22 @@ All analysis parameters, thresholds, plot dimensions, and algorithmic constants 
                     * Clear disclaimers that recommendations are starting points, not absolute values
                     * Works for all aircraft sizes including 10"+ where D > P (P:D < 1.0)
                 * Recommendations appear in both console output and step response plot legends
-            * **Other plots generated (`src/plot_functions/`):** Which plots are generated is controlled by the `PlotConfig` struct. The default (`--core`) enables the core set; `--extended` enables all plots except Bode; individual flags enable specific subsets. Plots are gated per-field in `PlotConfig`:
-                * **Core plots (default):**
+            * **Other plots generated (`src/plot_functions/`):** Which plots are generated is controlled by the `PlotConfig` struct. The default (no flag) enables the core set; `--extended` enables all plots except Bode. Plots are gated per-field in `PlotConfig`:
+                * **Core plots (default — no flag required):**
                     * `plot_setpoint_vs_gyro`: Setpoint and filtered gyro time-domain comparison for each axis.
                     * `plot_gyro_vs_unfilt`: Filtered vs. unfiltered gyro time-domain comparison for each axis. Includes enhanced cross-correlation filtering delay calculation.
                     * `plot_gyro_spectrums`: Frequency-domain amplitude spectrums of filtered and unfiltered gyro data with intelligent peak detection and labeling using scale-aware thresholds (`FILTERED_GYRO_MIN_THRESHOLD` for filtered gyro data). Includes enhanced cross-correlation filtering delay calculation and flight firmware filter response curve overlays.
                     * `plot_d_term_spectrums`: Frequency-domain amplitude spectrums of D-term data with intelligent peak detection using scale-aware thresholds (`FILTERED_D_TERM_MIN_THRESHOLD` for filtered D-term data). Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0).
                     * `plot_motor_spectrums`: Motor output frequency analysis.
-                * **Extended plots (`--extended` or individual flags):**
-                    * `plot_pidsum_error_setpoint`: PIDsum (P+I+D), PID Error (Setpoint - GyroADC), and Setpoint time-domain traces for each axis. (`--pid`)
-                    * `plot_pid_activity`: P, I, D term activity over time. (`--pid`)
-                    * `plot_setpoint_derivative`: Setpoint rate-of-change (feed-forward proxy) for each axis. (`--setpoint`)
-                    * `plot_psd`: Power Spectral Density plots in dB scale with peak labeling. Includes enhanced cross-correlation filtering delay calculation. (`--psd`)
-                    * `plot_d_term_psd`: Power Spectral Density plots of D-term data in dB scale with intelligent threshold filtering (`PSD_PEAK_LABEL_MIN_VALUE_DB` for filtered data) and enhanced formatting. Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0). (`--psd`)
-                    * `plot_d_term_heatmap`: D-term throttle-frequency heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze D-term energy distribution across different throttle levels. (`--heatmaps`)
-                    * `plot_psd_db_heatmap`: Spectrograms showing PSD vs. time as heatmaps using Short-Time Fourier Transform (STFT) with configurable window duration and overlap. (`--heatmaps`)
-                    * `plot_throttle_freq_heatmap`: Heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze noise characteristics across different throttle levels. (`--heatmaps`)
+                * **Extended plots (`--extended` adds these to the core set):**
+                    * `plot_pidsum_error_setpoint`: PIDsum (P+I+D), PID Error (Setpoint - GyroADC), and Setpoint time-domain traces for each axis.
+                    * `plot_pid_activity`: P, I, D term activity over time.
+                    * `plot_setpoint_derivative`: Setpoint rate-of-change (feed-forward proxy) for each axis.
+                    * `plot_psd`: Power Spectral Density plots in dB scale with peak labeling. Includes enhanced cross-correlation filtering delay calculation.
+                    * `plot_d_term_psd`: Power Spectral Density plots of D-term data in dB scale with intelligent threshold filtering (`PSD_PEAK_LABEL_MIN_VALUE_DB` for filtered data) and enhanced formatting. Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0).
+                    * `plot_d_term_heatmap`: D-term throttle-frequency heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze D-term energy distribution across different throttle levels.
+                    * `plot_psd_db_heatmap`: Spectrograms showing PSD vs. time as heatmaps using Short-Time Fourier Transform (STFT) with configurable window duration and overlap.
+                    * `plot_throttle_freq_heatmap`: Heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze noise characteristics across different throttle levels.
 
 ### Filtering Delay Calculation
 

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -23,7 +23,7 @@ All analysis parameters, thresholds, plot dimensions, and algorithmic constants 
 ### Core Functionality
 
 1.  **Argument Parsing (`src/main.rs`):**
-    * Parses command-line arguments: input CSV file(s), an optional `--dps` parameter (requires a numeric threshold value for detailed step response plots with low/high split), an optional `--output-dir` for specifying the output directory, and plot-selection flags (`--core` [default], `--extended`, `--step`, `--motor`, `--spectrums`, `--tracking`, `--gyro-filt`, `--pid`, `--psd`, `--heatmaps`, `--bode`).
+    * Parses command-line arguments: input CSV file(s), an optional `--dps` parameter (requires a numeric threshold value for detailed step response plots with low/high split), an optional `--output-dir` for specifying the output directory, and plot-selection flags (`--core` [default], `--extended`, `--step`, `--motor`, `--spectrums`, `--tracking`, `--gyro-filt`, `--setpoint`, `--pid`, `--psd`, `--heatmaps`, `--bode`).
     * Additional options include `--help` and `--version` for user assistance.
     * The `--output-dir` parameter now requires a directory path when specified. If omitted, plots are saved in the source folder (input file's directory).
     * Handles multiple input files and determines if a directory prefix should be added to output filenames to avoid collisions when processing files from different directories.
@@ -101,7 +101,7 @@ All analysis parameters, thresholds, plot dimensions, and algorithmic constants 
                 * **Extended plots (`--extended` or individual flags):**
                     * `plot_pidsum_error_setpoint`: PIDsum (P+I+D), PID Error (Setpoint - GyroADC), and Setpoint time-domain traces for each axis. (`--pid`)
                     * `plot_pid_activity`: P, I, D term activity over time. (`--pid`)
-                    * `plot_setpoint_derivative`: Setpoint rate-of-change (feed-forward proxy) for each axis. (`--pid`)
+                    * `plot_setpoint_derivative`: Setpoint rate-of-change (feed-forward proxy) for each axis. (`--setpoint`)
                     * `plot_psd`: Power Spectral Density plots in dB scale with peak labeling. Includes enhanced cross-correlation filtering delay calculation. (`--psd`)
                     * `plot_d_term_psd`: Power Spectral Density plots of D-term data in dB scale with intelligent threshold filtering (`PSD_PEAK_LABEL_MIN_VALUE_DB` for filtered data) and enhanced formatting. Includes enhanced cross-correlation filtering delay calculation with intelligent D-term activity detection (skips axes where D gain = 0). (`--psd`)
                     * `plot_d_term_heatmap`: D-term throttle-frequency heatmaps showing PSD vs. throttle (Y-axis) and frequency (X-axis) to analyze D-term energy distribution across different throttle levels. (`--heatmaps`)

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -23,7 +23,7 @@ All analysis parameters, thresholds, plot dimensions, and algorithmic constants 
 ### Core Functionality
 
 1.  **Argument Parsing (`src/main.rs`):**
-    * Parses command-line arguments: input CSV file(s), an optional `--dps` parameter (requires a numeric threshold value for detailed step response plots with low/high split), an optional `--output-dir` for specifying the output directory, and plot-selection flags (`--extended`, `--step`, `--bode`). Default with no plot flag generates core plots.
+    * Parses command-line arguments: input CSV file(s), an optional `--dps` parameter (requires a numeric threshold value for detailed step response plots with low/high split), an optional `--output-dir` for specifying the output directory, and plot-selection flags (`--core` [default], `--extended`, `--step`, `--bode`).
     * Additional options include `--help` and `--version` for user assistance.
     * The `--output-dir` parameter now requires a directory path when specified. If omitted, plots are saved in the source folder (input file's directory).
     * Handles multiple input files and determines if a directory prefix should be added to output filenames to avoid collisions when processing files from different directories.

--- a/README.md
+++ b/README.md
@@ -36,13 +36,22 @@ Usage: ./BlackBox_CSV_Render <input1> [<input2> ...] [OPTIONS]
 
 === PLOT TYPE SELECTION ===
 
-  Note: Plot flags are combinable. Without flags, all plots generated.
+  Note: Plot flags are combinable and switch the application to "Only" mode.
 
-  --step: Generate only step response plots.
-  --motor: Generate only motor spectrum plots.
-  --setpoint: Generate only setpoint-related plots.
-  --pid: Generate only P, I, D activity plot.
-  --bode: Bode plot analysis (requires chirp/sweep system-id test flight, not normal logs).
+  --core:          Generate core plots (Step, Spectrums, Tracking, Latency) [DEFAULT].
+  --extended:      Generate all plots (except Bode).
+
+  --step:          Generate only step response plots.
+  --motor:         Generate only motor spectrum plots.
+  --spectrums:     Generate only gyro and D-term spectrum plots.
+  --tracking:      Generate only setpoint vs gyro tracking plot.
+  --gyro-filt:     Generate only gyro vs unfiltered (latency) plot.
+  --setpoint:      Generate only setpoint-related plots (Tracking & FF).
+  --pid:           Generate only PID-related plots (Activity & Error).
+  --psd:           Generate only PSD plots (Gyro & D-term).
+  --heatmaps:      Generate only spectral heatmaps.
+  --setpoint-diff: Generate only setpoint derivative (FF) plot.
+  --bode:          Bode plot analysis (requires chirp/sweep system-id test flight).
 
 === ANALYSIS OPTIONS ===
 

--- a/README.md
+++ b/README.md
@@ -39,31 +39,25 @@ Usage: ./BlackBox_CSV_Render <input1> [<input2> ...] [OPTIONS]
 
 === PLOT TYPE SELECTION ===
 
-  Default (no flag): Core plots — Step Response, Gyro Spectrums, D-term Spectrums,
-                     Setpoint vs Gyro, Gyro vs Unfiltered, Motor Spectrums.
-
-  --extended:      All plots except Bode — adds PIDsum/Error, PID Activity,
-                   Setpoint Derivative, Gyro PSD, D-term PSD, and heatmaps
-                   (Gyro Spectrogram, Throttle/Freq, D-term) to the core set.
-
-  --step:          Step response plots only.
-  --bode:          Bode plot only (requires chirp/sweep system-id test flight).
-
-  --extended and --step/--bode are combinable: --extended --bode adds Bode to
-  the full set; --step --bode generates both in isolation.
+  --core           [default] Step Response, Gyro Spectrums, D-term Spectrums,
+                   Setpoint vs Gyro, Gyro vs Unfiltered, Motor Spectrums.
+  --extended       All plots except Bode — adds PIDsum/Error, PID Activity,
+                   Setpoint Derivative, Gyro PSD, D-term PSD, and heatmaps.
+  --step           Step response only.
+  --bode           Bode only (requires chirp/sweep system-id test flight).
 
 === ANALYSIS OPTIONS ===
 
-  --butterworth: Show Butterworth PT1 cutoffs on gyro/D-term spectrum plots.
-  --dps <value>: Deg/s threshold for detailed step response plots (positive number).
-  --estimate-optimal-p: [EXPERIMENTAL] Optimal P estimation from throttle-punch
+  --butterworth    Show Butterworth PT1 cutoffs on gyro/D-term spectrum plots.
+  --dps <value>    Deg/s threshold for detailed step response plots (positive number).
+  --estimate-optimal-p  [EXPERIMENTAL] Optimal P estimation from throttle-punch
                         dynamics. Requires .headers.csv; skips if absent.
 
 === GENERAL ===
 
-  --debug: Show detailed metadata during processing.
-  -h, --help: Show this help message and exit.
-  -V, --version: Show version information.
+  --debug          Show detailed metadata during processing.
+  -h, --help       Show this help message and exit.
+  -V, --version    Show version information.
 ```
 
 Arguments can be in any order. Wildcards (e.g., *.csv) are shell-expanded and work with mixed file/directory patterns.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ cargo build --release
 
 ### Usage
 
-> **Notice:** Default output changed to **core plots only** (Step, Spectrums, Tracking, Latency, Motor).
-> Scripts or workflows that previously relied on all plots being generated without flags should add `--extended` to restore the full set.
+> **Notice:** Default output is **core plots only**. Use `--extended` for all plots.
 
 ```shell
 Usage: ./BlackBox_CSV_Render <input1> [<input2> ...] [OPTIONS]
@@ -40,27 +39,25 @@ Usage: ./BlackBox_CSV_Render <input1> [<input2> ...] [OPTIONS]
 
 === PLOT TYPE SELECTION ===
 
-  Note: Plot flags are combinable and switch the application to "Only" mode.
+  Default (no flag): Core plots — Step Response, Gyro Spectrums, D-term Spectrums,
+                     Setpoint vs Gyro, Gyro vs Unfiltered, Motor Spectrums.
 
-  --core:          Generate core plots (Step, Spectrums, Tracking, Latency, Motor) [DEFAULT].
-  --extended:      Generate all plots (except Bode).
+  --extended:      All plots except Bode — adds PIDsum/Error, PID Activity,
+                   Setpoint Derivative, Gyro PSD, D-term PSD, and heatmaps
+                   (Gyro Spectrogram, Throttle/Freq, D-term) to the core set.
 
-  --step:          Generate only step response plots.
-  --motor:         Generate only motor spectrum plots.
-  --spectrums:     Generate only gyro and D-term spectrum plots.
-  --tracking:      Generate only setpoint vs gyro tracking plot.
-  --gyro-filt:     Generate only gyro vs unfiltered (latency) plot.
-  --setpoint:      Generate only setpoint-related plots (Tracking & FF).
-  --pid:           Generate only PID-related plots (Activity & Error).
-  --psd:           Generate only PSD plots (Gyro & D-term).
-  --heatmaps:      Generate only spectral heatmaps.
-  --bode:          Bode plot analysis (requires chirp/sweep system-id test flight).
+  --step:          Step response plots only.
+  --bode:          Bode plot only (requires chirp/sweep system-id test flight).
+
+  --extended and --step/--bode are combinable: --extended --bode adds Bode to
+  the full set; --step --bode generates both in isolation.
 
 === ANALYSIS OPTIONS ===
 
   --butterworth: Show Butterworth PT1 cutoffs on gyro/D-term spectrum plots.
   --dps <value>: Deg/s threshold for detailed step response plots (positive number).
-  --estimate-optimal-p: Enable optimal P estimation from throttle-punch dynamics. Requires .headers.csv; skips P estimation if absent.
+  --estimate-optimal-p: [EXPERIMENTAL] Optimal P estimation from throttle-punch
+                        dynamics. Requires .headers.csv; skips if absent.
 
 === GENERAL ===
 
@@ -70,6 +67,7 @@ Usage: ./BlackBox_CSV_Render <input1> [<input2> ...] [OPTIONS]
 ```
 
 Arguments can be in any order. Wildcards (e.g., *.csv) are shell-expanded and work with mixed file/directory patterns.
+
 ### Example execution commands
 ```shell
 ./target/release/BlackBox_CSV_Render path/to/BTFL_Log.csv
@@ -84,10 +82,7 @@ Arguments can be in any order. Wildcards (e.g., *.csv) are shell-expanded and wo
 ./target/release/BlackBox_CSV_Render path/to/ -R --step --output-dir ./step-only
 ```
 ```shell
-./target/release/BlackBox_CSV_Render path/to/ --setpoint --output-dir ./setpoint-only
-```
-```shell
-./target/release/BlackBox_CSV_Render path/to/ --step --setpoint --motor --output-dir ./all-selective
+./target/release/BlackBox_CSV_Render path/to/ --extended --output-dir ./all-plots
 ```
 ```shell
 ./target/release/BlackBox_CSV_Render path/to/BTFL_Log.csv --step --estimate-optimal-p
@@ -97,7 +92,7 @@ Arguments can be in any order. Wildcards (e.g., *.csv) are shell-expanded and wo
 
 #### PNG Files Generated
 
-**Core (default / `--core`):**
+**Core (default):**
 - `*_Step_Response_stacked_plot_*.png` — Step response analysis with P:D recommendations
 - `*_SetpointVsGyro_stacked.png` — Setpoint vs. filtered gyro comparison
 - `*_GyroVsUnfilt_stacked.png` — Filtered vs. unfiltered gyro comparison with delay estimates
@@ -105,15 +100,15 @@ Arguments can be in any order. Wildcards (e.g., *.csv) are shell-expanded and wo
 - `*_D_Term_Spectrums_comparative.png` — Frequency-domain D-term amplitude spectrums
 - `*_Motor_Spectrums_stacked.png` — Motor output frequency analysis (supports any motor count; colors wrap every 8 motors)
 
-**Extended (`--extended`, or via individual flags):**
-- `*_PIDsum_PIDerror_Setpoint_stacked.png` — PIDsum, PID error, and setpoint traces (`--pid`)
-- `*_PID_Activity_stacked.png` — P, I, D term activity over time (`--pid`)
-- `*_SetpointDerivative_stacked.png` — Setpoint rate-of-change / feed-forward proxy (`--setpoint`)
-- `*_Gyro_PSD_comparative.png` — Gyro power spectral density (dB scale) (`--psd`)
-- `*_D_Term_PSD_comparative.png` — D-term power spectral density (dB scale) (`--psd`)
-- `*_D_Term_Heatmap_comparative.png` — D-term throttle/frequency heatmap (`--heatmaps`)
-- `*_Gyro_PSD_Spectrogram_comparative.png` — Gyro spectrogram (PSD vs. time) (`--heatmaps`)
-- `*_Throttle_Freq_Heatmap_comparative.png` — Throttle/frequency heatmap analysis (`--heatmaps`)
+**Extended (`--extended` adds these to the core set):**
+- `*_PIDsum_PIDerror_Setpoint_stacked.png` — PIDsum, PID error, and setpoint traces
+- `*_PID_Activity_stacked.png` — P, I, D term activity over time
+- `*_SetpointDerivative_stacked.png` — Setpoint rate-of-change / feed-forward proxy
+- `*_Gyro_PSD_comparative.png` — Gyro power spectral density (dB scale)
+- `*_D_Term_PSD_comparative.png` — D-term power spectral density (dB scale)
+- `*_D_Term_Heatmap_comparative.png` — D-term throttle/frequency heatmap
+- `*_Gyro_PSD_Spectrogram_comparative.png` — Gyro spectrogram (PSD vs. time)
+- `*_Throttle_Freq_Heatmap_comparative.png` — Throttle/frequency heatmap analysis
 
 #### Console Output:
 - Current P:D ratio and peak analysis with response assessment

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Usage: ./BlackBox_CSV_Render <input1> [<input2> ...] [OPTIONS]
   --pid:           Generate only PID-related plots (Activity & Error).
   --psd:           Generate only PSD plots (Gyro & D-term).
   --heatmaps:      Generate only spectral heatmaps.
-  --setpoint-diff: Generate only setpoint derivative (FF) plot.
   --bode:          Bode plot analysis (requires chirp/sweep system-id test flight).
 
 === ANALYSIS OPTIONS ===

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ cargo build --release
 ```
 
 ### Usage
+
+> **Notice:** Default output changed to **core plots only** (Step, Spectrums, Tracking, Latency, Motor).
+> Scripts or workflows that previously relied on all plots being generated without flags should add `--extended` to restore the full set.
+
 ```shell
 Usage: ./BlackBox_CSV_Render <input1> [<input2> ...] [OPTIONS]
 
@@ -92,19 +96,24 @@ Arguments can be in any order. Wildcards (e.g., *.csv) are shell-expanded and wo
 ### Output
 
 #### PNG Files Generated
+
+**Core (default / `--core`):**
 - `*_Step_Response_stacked_plot_*.png` — Step response analysis with P:D recommendations
-- `*_PIDsum_PIDerror_Setpoint_stacked.png` — PIDsum, PID error, and setpoint traces
 - `*_SetpointVsGyro_stacked.png` — Setpoint vs. filtered gyro comparison
 - `*_GyroVsUnfilt_stacked.png` — Filtered vs. unfiltered gyro comparison with delay estimates
 - `*_Gyro_Spectrums_comparative.png` — Frequency-domain gyro amplitude spectrums
-- `*_Gyro_PSD_comparative.png` — Gyro power spectral density (dB scale)
 - `*_D_Term_Spectrums_comparative.png` — Frequency-domain D-term amplitude spectrums
-- `*_D_Term_PSD_comparative.png` — D-term power spectral density (dB scale)
-- `*_D_Term_Heatmap_comparative.png` — D-term throttle/frequency heatmap
-- `*_Gyro_PSD_Spectrogram_comparative.png` — Gyro spectrogram (PSD vs. time)
-- `*_Throttle_Freq_Heatmap_comparative.png` — Throttle/frequency heatmap analysis
 - `*_Motor_Spectrums_stacked.png` — Motor output frequency analysis (supports any motor count; colors wrap every 8 motors)
-- `*_PID_Activity_stacked.png` — P, I, D term activity over time (stacked plot showing all three PID components)
+
+**Extended (`--extended`, or via individual flags):**
+- `*_PIDsum_PIDerror_Setpoint_stacked.png` — PIDsum, PID error, and setpoint traces (`--pid`)
+- `*_PID_Activity_stacked.png` — P, I, D term activity over time (`--pid`)
+- `*_SetpointDerivative_stacked.png` — Setpoint rate-of-change / feed-forward proxy (`--setpoint`)
+- `*_Gyro_PSD_comparative.png` — Gyro power spectral density (dB scale) (`--psd`)
+- `*_D_Term_PSD_comparative.png` — D-term power spectral density (dB scale) (`--psd`)
+- `*_D_Term_Heatmap_comparative.png` — D-term throttle/frequency heatmap (`--heatmaps`)
+- `*_Gyro_PSD_Spectrogram_comparative.png` — Gyro spectrogram (PSD vs. time) (`--heatmaps`)
+- `*_Throttle_Freq_Heatmap_comparative.png` — Throttle/frequency heatmap analysis (`--heatmaps`)
 
 #### Console Output:
 - Current P:D ratio and peak analysis with response assessment

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Usage: ./BlackBox_CSV_Render <input1> [<input2> ...] [OPTIONS]
   --spectrums:     Generate only gyro and D-term spectrum plots.
   --tracking:      Generate only setpoint vs gyro tracking plot.
   --gyro-filt:     Generate only gyro vs unfiltered (latency) plot.
-  --pid:           Generate only PID-related plots (Tracking, FF, Activity & Error).
+  --setpoint:      Generate only setpoint-related plots (Tracking & FF).
+  --pid:           Generate only PID-related plots (Activity & Error).
   --psd:           Generate only PSD plots (Gyro & D-term).
   --heatmaps:      Generate only spectral heatmaps.
   --bode:          Bode plot analysis (requires chirp/sweep system-id test flight).
@@ -107,7 +108,7 @@ Arguments can be in any order. Wildcards (e.g., *.csv) are shell-expanded and wo
 **Extended (`--extended`, or via individual flags):**
 - `*_PIDsum_PIDerror_Setpoint_stacked.png` — PIDsum, PID error, and setpoint traces (`--pid`)
 - `*_PID_Activity_stacked.png` — P, I, D term activity over time (`--pid`)
-- `*_SetpointDerivative_stacked.png` — Setpoint rate-of-change / feed-forward proxy (`--pid`)
+- `*_SetpointDerivative_stacked.png` — Setpoint rate-of-change / feed-forward proxy (`--setpoint`)
 - `*_Gyro_PSD_comparative.png` — Gyro power spectral density (dB scale) (`--psd`)
 - `*_D_Term_PSD_comparative.png` — D-term power spectral density (dB scale) (`--psd`)
 - `*_D_Term_Heatmap_comparative.png` — D-term throttle/frequency heatmap (`--heatmaps`)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Usage: ./BlackBox_CSV_Render <input1> [<input2> ...] [OPTIONS]
 
   Note: Plot flags are combinable and switch the application to "Only" mode.
 
-  --core:          Generate core plots (Step, Spectrums, Tracking, Latency) [DEFAULT].
+  --core:          Generate core plots (Step, Spectrums, Tracking, Latency, Motor) [DEFAULT].
   --extended:      Generate all plots (except Bode).
 
   --step:          Generate only step response plots.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ Usage: ./BlackBox_CSV_Render <input1> [<input2> ...] [OPTIONS]
   --spectrums:     Generate only gyro and D-term spectrum plots.
   --tracking:      Generate only setpoint vs gyro tracking plot.
   --gyro-filt:     Generate only gyro vs unfiltered (latency) plot.
-  --setpoint:      Generate only setpoint-related plots (Tracking & FF).
-  --pid:           Generate only PID-related plots (Activity & Error).
+  --pid:           Generate only PID-related plots (Tracking, FF, Activity & Error).
   --psd:           Generate only PSD plots (Gyro & D-term).
   --heatmaps:      Generate only spectral heatmaps.
   --bode:          Bode plot analysis (requires chirp/sweep system-id test flight).
@@ -108,7 +107,7 @@ Arguments can be in any order. Wildcards (e.g., *.csv) are shell-expanded and wo
 **Extended (`--extended`, or via individual flags):**
 - `*_PIDsum_PIDerror_Setpoint_stacked.png` — PIDsum, PID error, and setpoint traces (`--pid`)
 - `*_PID_Activity_stacked.png` — P, I, D term activity over time (`--pid`)
-- `*_SetpointDerivative_stacked.png` — Setpoint rate-of-change / feed-forward proxy (`--setpoint`)
+- `*_SetpointDerivative_stacked.png` — Setpoint rate-of-change / feed-forward proxy (`--pid`)
 - `*_Gyro_PSD_comparative.png` — Gyro power spectral density (dB scale) (`--psd`)
 - `*_D_Term_PSD_comparative.png` — D-term power spectral density (dB scale) (`--psd`)
 - `*_D_Term_Heatmap_comparative.png` — D-term throttle/frequency heatmap (`--heatmaps`)

--- a/src/data_input/log_parser.rs
+++ b/src/data_input/log_parser.rs
@@ -216,7 +216,9 @@ pub fn parse_log_file(input_file_path: &Path, debug_mode: bool) -> LogParseResul
             .trim(csv::Trim::All)
             .from_reader(BufReader::new(file));
         let header_record = reader.headers()?.clone();
-        println!("Flight data keys found in CSV: {header_record:?}");
+        if debug_mode {
+            println!("Flight data keys found in CSV: {header_record:?}");
+        }
 
         // Detect motor channels dynamically (motor[0] through motor[N-1])
         // Collect all motor headers with their (motor_num, csv_idx) pairs, allowing out-of-order
@@ -271,12 +273,14 @@ pub fn parse_log_file(input_file_path: &Path, debug_mode: bool) -> LogParseResul
                 motor_indices.push(*csv_idx);
             }
 
-            println!(
-                "Detected {} motor outputs: motor[{}] through motor[{}]",
-                motor_indices.len(),
-                motor_pairs.first().map(|&(n, _)| n).unwrap_or(0),
-                motor_pairs.last().map(|&(n, _)| n).unwrap_or(0)
-            );
+            if debug_mode {
+                println!(
+                    "Detected {} motor outputs: motor[{}] through motor[{}]",
+                    motor_indices.len(),
+                    motor_pairs.first().map(|&(n, _)| n).unwrap_or(0),
+                    motor_pairs.last().map(|&(n, _)| n).unwrap_or(0)
+                );
+            }
         }
 
         header_indices = target_headers
@@ -295,7 +299,9 @@ pub fn parse_log_file(input_file_path: &Path, debug_mode: bool) -> LogParseResul
             })
             .collect();
 
-        println!("Flight data key mapping:");
+        if debug_mode {
+            println!("Flight data key mapping:");
+        }
         let mut essential_pid_headers_found = true;
 
         // Check essential PID headers (Time, P, I, D[0], D[1]).
@@ -303,11 +309,13 @@ pub fn parse_log_file(input_file_path: &Path, debug_mode: bool) -> LogParseResul
             // Indices 0 through 8
             let name = target_headers[i];
             let found = header_indices[i].is_some();
-            println!(
-                "  '{}': {}",
-                name,
-                if found { "Found" } else { "Not Found" }
-            );
+            if debug_mode {
+                println!(
+                    "  '{}': {}",
+                    name,
+                    if found { "Found" } else { "Not Found" }
+                );
+            }
             if !found {
                 essential_pid_headers_found = false;
             }
@@ -315,23 +323,11 @@ pub fn parse_log_file(input_file_path: &Path, debug_mode: bool) -> LogParseResul
 
         // Check optional 'axisD[2]' header (Index 9).
         let axis_d2_found_in_csv = header_indices[9].is_some();
-        println!(
-            "  '{}': {} (Optional, defaults to 0.0 if not found)",
-            target_headers[9],
-            if axis_d2_found_in_csv {
-                "Found"
-            } else {
-                "Not Found"
-            }
-        );
-
-        // Check f_term headers (Indices 10-12).
-        for axis in 0..crate::axis_names::AXIS_NAMES.len() {
-            f_term_header_found[axis] = header_indices[10 + axis].is_some();
+        if debug_mode {
             println!(
                 "  '{}': {} (Optional, defaults to 0.0 if not found)",
-                target_headers[10 + axis],
-                if f_term_header_found[axis] {
+                target_headers[9],
+                if axis_d2_found_in_csv {
                     "Found"
                 } else {
                     "Not Found"
@@ -339,75 +335,99 @@ pub fn parse_log_file(input_file_path: &Path, debug_mode: bool) -> LogParseResul
             );
         }
 
+        // Check f_term headers (Indices 10-12).
+        for axis in 0..crate::axis_names::AXIS_NAMES.len() {
+            f_term_header_found[axis] = header_indices[10 + axis].is_some();
+            if debug_mode {
+                println!(
+                    "  '{}': {} (Optional, defaults to 0.0 if not found)",
+                    target_headers[10 + axis],
+                    if f_term_header_found[axis] {
+                        "Found"
+                    } else {
+                        "Not Found"
+                    }
+                );
+            }
+        }
+
         // Check setpoint headers (Indices 13-16).
         for axis in 0..4 {
             // Check setpoint[0] to setpoint[3]
             setpoint_header_found[axis] = header_indices[13 + axis].is_some();
-            let purpose = if axis < 3 {
-                format!("Essential for Setpoint plots and Step Response Axis {axis}")
-            } else {
-                "Throttle (setpoint[3])".to_string()
-            };
-            println!(
-                "  '{}': {} ({})",
-                target_headers[13 + axis],
-                if setpoint_header_found[axis] {
-                    "Found"
+            if debug_mode {
+                let purpose = if axis < 3 {
+                    format!("Essential for Setpoint plots and Step Response Axis {axis}")
                 } else {
-                    "Not Found"
-                },
-                purpose
-            );
+                    "Throttle (setpoint[3])".to_string()
+                };
+                println!(
+                    "  '{}': {} ({})",
+                    target_headers[13 + axis],
+                    if setpoint_header_found[axis] {
+                        "Found"
+                    } else {
+                        "Not Found"
+                    },
+                    purpose
+                );
+            }
         }
 
         // Check gyro (filtered) headers (Indices 17-19).
         for axis in 0..crate::axis_names::AXIS_NAMES.len() {
             gyro_header_found[axis] = header_indices[17 + axis].is_some();
-            println!(
-                "  '{}': {} (Essential for Step Response, Gyro plots, and PID Error Axis {})",
-                target_headers[17 + axis],
-                if gyro_header_found[axis] {
-                    "Found"
-                } else {
-                    "Not Found"
-                },
-                axis
-            );
+            if debug_mode {
+                println!(
+                    "  '{}': {} (Essential for Step Response, Gyro plots, and PID Error Axis {})",
+                    target_headers[17 + axis],
+                    if gyro_header_found[axis] {
+                        "Found"
+                    } else {
+                        "Not Found"
+                    },
+                    axis
+                );
+            }
         }
 
         // Check gyroUnfilt headers (Indices 20-22).
         for axis in 0..crate::axis_names::AXIS_NAMES.len() {
             gyro_unfilt_header_found[axis] = header_indices[20 + axis].is_some();
-            println!(
-                "  '{}': {} (Fallback for Gyro vs Unfilt Axis {})",
-                target_headers[20 + axis],
-                if gyro_unfilt_header_found[axis] {
-                    "Found"
-                } else {
-                    "Not Found"
-                },
-                axis
-            );
+            if debug_mode {
+                println!(
+                    "  '{}': {} (Fallback for Gyro vs Unfilt Axis {})",
+                    target_headers[20 + axis],
+                    if gyro_unfilt_header_found[axis] {
+                        "Found"
+                    } else {
+                        "Not Found"
+                    },
+                    axis
+                );
+            }
         }
 
         // Check debug headers (Indices 23-26).
         for idx_offset in 0..4 {
             debug_header_found[idx_offset] = header_indices[23 + idx_offset].is_some();
-            let purpose = if idx_offset < 3 {
-                "Fallback for gyroUnfilt[0-2]"
-            } else {
-                "Optional debug channel"
-            };
-            println!(
-                "  '{}': {} ({})",
-                target_headers[23 + idx_offset],
-                if debug_header_found[idx_offset] {
-                    "Found"
+            if debug_mode {
+                let purpose = if idx_offset < 3 {
+                    "Fallback for gyroUnfilt[0-2]"
                 } else {
-                    "Not Found"
-                },
-                purpose
-            );
+                    "Optional debug channel"
+                };
+                println!(
+                    "  '{}': {} ({})",
+                    target_headers[23 + idx_offset],
+                    if debug_header_found[idx_offset] {
+                        "Found"
+                    } else {
+                        "Not Found"
+                    },
+                    purpose
+                );
+            }
         }
 
         if !essential_pid_headers_found {

--- a/src/main.rs
+++ b/src/main.rs
@@ -386,33 +386,27 @@ fn print_usage_and_exit(program_name: &str) {
     eprintln!();
     eprintln!("=== PLOT TYPE SELECTION ===");
     eprintln!();
-    eprintln!("  Default (no flag): Core plots — Step Response, Gyro Spectrums, D-term Spectrums,");
-    eprintln!("                     Setpoint vs Gyro, Gyro vs Unfiltered, Motor Spectrums.");
-    eprintln!();
-    eprintln!("  --extended:      All plots except Bode — adds PIDsum/Error, PID Activity,");
-    eprintln!("                   Setpoint Derivative, Gyro PSD, D-term PSD, and heatmaps");
-    eprintln!("                   (Gyro Spectrogram, Throttle/Freq, D-term) to the core set.");
-    eprintln!();
-    eprintln!("  --step:          Step response plots only.");
-    eprintln!("  --bode:          Bode plot only (requires chirp/sweep system-id test flight).");
-    eprintln!();
-    eprintln!("  --extended and --step/--bode are combinable: --extended --bode adds Bode to");
-    eprintln!("  the full set; --step --bode generates both in isolation.");
+    eprintln!("  --core           [default] Step Response, Gyro Spectrums, D-term Spectrums,");
+    eprintln!("                   Setpoint vs Gyro, Gyro vs Unfiltered, Motor Spectrums.");
+    eprintln!("  --extended       All plots except Bode — adds PIDsum/Error, PID Activity,");
+    eprintln!("                   Setpoint Derivative, Gyro PSD, D-term PSD, and heatmaps.");
+    eprintln!("  --step           Step response only.");
+    eprintln!("  --bode           Bode only (requires chirp/sweep system-id test flight).");
     eprintln!();
     eprintln!("=== ANALYSIS OPTIONS ===");
     eprintln!();
-    eprintln!("  --butterworth: Show Butterworth PT1 cutoffs on gyro/D-term spectrum plots.");
+    eprintln!("  --butterworth    Show Butterworth PT1 cutoffs on gyro/D-term spectrum plots.");
     eprintln!(
-        "  --dps <value>: Deg/s threshold for detailed step response plots (positive number)."
+        "  --dps <value>    Deg/s threshold for detailed step response plots (positive number)."
     );
-    eprintln!("  --estimate-optimal-p: [EXPERIMENTAL] Optimal P estimation from throttle-punch");
+    eprintln!("  --estimate-optimal-p  [EXPERIMENTAL] Optimal P estimation from throttle-punch");
     eprintln!("                        dynamics. Requires .headers.csv; skips if absent.");
     eprintln!();
     eprintln!("=== GENERAL ===");
     eprintln!();
-    eprintln!("  --debug: Show detailed metadata during processing.");
-    eprintln!("  -h, --help: Show this help message and exit.");
-    eprintln!("  -V, --version: Show version information.");
+    eprintln!("  --debug          Show detailed metadata during processing.");
+    eprintln!("  -h, --help       Show this help message and exit.");
+    eprintln!("  -V, --version    Show version information.");
     std::process::exit(1);
 }
 
@@ -1540,9 +1534,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut output_dir: Option<String> = None; // None = not specified (use source folder), Some(dir) = --output-dir with value
     let mut debug_mode = false;
     let mut show_butterworth = false;
+    let mut core_requested = false;
+    let mut extended_requested = false;
     let mut step_requested = false;
     let mut bode_requested = false;
-    let mut extended_requested = false;
     let mut recursive = false;
     let mut estimate_optimal_p = false;
 
@@ -1597,12 +1592,14 @@ fn main() -> Result<(), Box<dyn Error>> {
             debug_mode = true;
         } else if arg == "--butterworth" {
             show_butterworth = true;
+        } else if arg == "--core" {
+            core_requested = true;
+        } else if arg == "--extended" {
+            extended_requested = true;
         } else if arg == "--step" {
             step_requested = true;
         } else if arg == "--bode" {
             bode_requested = true;
-        } else if arg == "--extended" {
-            extended_requested = true;
         } else if arg == "--estimate-optimal-p" {
             estimate_optimal_p = true;
         } else if arg.starts_with("--") {
@@ -1612,6 +1609,11 @@ fn main() -> Result<(), Box<dyn Error>> {
             input_paths.push(arg.clone());
         }
         i += 1;
+    }
+
+    if core_requested && extended_requested {
+        eprintln!("Error: --core and --extended are mutually exclusive.");
+        print_usage_and_exit(program_name);
     }
 
     // Derive plot configuration from flags

--- a/src/main.rs
+++ b/src/main.rs
@@ -386,25 +386,18 @@ fn print_usage_and_exit(program_name: &str) {
     eprintln!();
     eprintln!("=== PLOT TYPE SELECTION ===");
     eprintln!();
-    eprintln!("  Note: Plot flags are combinable and switch the application to \"Only\" mode.");
+    eprintln!("  Default (no flag): Core plots — Step Response, Gyro Spectrums, D-term Spectrums,");
+    eprintln!("                     Setpoint vs Gyro, Gyro vs Unfiltered, Motor Spectrums.");
     eprintln!();
-    eprintln!(
-        "  --core:          Generate core plots (Step, Spectrums, Tracking, Latency, Motor) [DEFAULT]."
-    );
-    eprintln!("  --extended:      Generate all plots (except Bode).");
+    eprintln!("  --extended:      All plots except Bode — adds PIDsum/Error, PID Activity,");
+    eprintln!("                   Setpoint Derivative, Gyro PSD, D-term PSD, and heatmaps");
+    eprintln!("                   (Gyro Spectrogram, Throttle/Freq, D-term) to the core set.");
     eprintln!();
-    eprintln!("  --step:          Generate only step response plots.");
-    eprintln!("  --motor:         Generate only motor spectrum plots.");
-    eprintln!("  --spectrums:     Generate only gyro and D-term spectrum plots.");
-    eprintln!("  --tracking:      Generate only setpoint vs gyro tracking plot.");
-    eprintln!("  --gyro-filt:     Generate only gyro vs unfiltered (latency) plot.");
-    eprintln!("  --setpoint:      Generate only setpoint-related plots (Tracking & FF).");
-    eprintln!("  --pid:           Generate only PID-related plots (Activity & Error).");
-    eprintln!("  --psd:           Generate only PSD plots (Gyro & D-term).");
-    eprintln!("  --heatmaps:      Generate only spectral heatmaps.");
-    eprintln!(
-        "  --bode:          Bode plot analysis (requires chirp/sweep system-id test flight)."
-    );
+    eprintln!("  --step:          Step response plots only.");
+    eprintln!("  --bode:          Bode plot only (requires chirp/sweep system-id test flight).");
+    eprintln!();
+    eprintln!("  --extended and --step/--bode are combinable: --extended --bode adds Bode to");
+    eprintln!("  the full set; --step --bode generates both in isolation.");
     eprintln!();
     eprintln!("=== ANALYSIS OPTIONS ===");
     eprintln!();
@@ -412,7 +405,8 @@ fn print_usage_and_exit(program_name: &str) {
     eprintln!(
         "  --dps <value>: Deg/s threshold for detailed step response plots (positive number)."
     );
-    eprintln!("  --estimate-optimal-p: Enable optimal P estimation from throttle-punch dynamics. Requires .headers.csv; skips P estimation if absent.");
+    eprintln!("  --estimate-optimal-p: [EXPERIMENTAL] Optimal P estimation from throttle-punch");
+    eprintln!("                        dynamics. Requires .headers.csv; skips if absent.");
     eprintln!();
     eprintln!("=== GENERAL ===");
     eprintln!();
@@ -1546,19 +1540,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut output_dir: Option<String> = None; // None = not specified (use source folder), Some(dir) = --output-dir with value
     let mut debug_mode = false;
     let mut show_butterworth = false;
-    let mut plot_config = PlotConfig::default();
-    let mut has_only_flags = false;
     let mut step_requested = false;
-    let mut motor_requested = false;
-    let mut spectrums_requested = false;
-    let mut tracking_requested = false;
-    let mut gyro_filt_requested = false;
-    let mut setpoint_requested = false;
     let mut bode_requested = false;
-    let mut pid_requested = false;
-    let mut psd_requested = false;
-    let mut heatmaps_requested = false;
-    let mut core_requested = false;
     let mut extended_requested = false;
     let mut recursive = false;
     let mut estimate_optimal_p = false;
@@ -1615,40 +1598,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         } else if arg == "--butterworth" {
             show_butterworth = true;
         } else if arg == "--step" {
-            has_only_flags = true;
             step_requested = true;
-        } else if arg == "--motor" {
-            has_only_flags = true;
-            motor_requested = true;
-        } else if arg == "--spectrums" {
-            has_only_flags = true;
-            spectrums_requested = true;
-        } else if arg == "--tracking" {
-            has_only_flags = true;
-            tracking_requested = true;
-        } else if arg == "--gyro-filt" {
-            has_only_flags = true;
-            gyro_filt_requested = true;
-        } else if arg == "--setpoint" {
-            has_only_flags = true;
-            setpoint_requested = true;
         } else if arg == "--bode" {
-            has_only_flags = true;
             bode_requested = true;
-        } else if arg == "--pid" {
-            has_only_flags = true;
-            pid_requested = true;
-        } else if arg == "--psd" {
-            has_only_flags = true;
-            psd_requested = true;
-        } else if arg == "--heatmaps" {
-            has_only_flags = true;
-            heatmaps_requested = true;
-        } else if arg == "--core" {
-            has_only_flags = true;
-            core_requested = true;
         } else if arg == "--extended" {
-            has_only_flags = true;
             extended_requested = true;
         } else if arg == "--estimate-optimal-p" {
             estimate_optimal_p = true;
@@ -1661,63 +1614,31 @@ fn main() -> Result<(), Box<dyn Error>> {
         i += 1;
     }
 
-    if core_requested && extended_requested {
-        eprintln!("Error: --core and --extended are mutually exclusive.");
-        print_usage_and_exit(program_name);
-    }
-
-    // Apply "only" flags if any were specified (non-mutually exclusive: OR together)
-    if has_only_flags {
-        plot_config = if core_requested {
-            PlotConfig::default()
-        } else if extended_requested {
-            PlotConfig::all()
-        } else {
-            PlotConfig::none()
-        };
+    // Derive plot configuration from flags
+    let plot_config = if extended_requested {
+        let mut cfg = PlotConfig::all();
+        if bode_requested {
+            cfg.bode = true;
+        }
+        cfg
+    } else if step_requested || bode_requested {
+        let mut cfg = PlotConfig::none();
         if step_requested {
-            plot_config.step_response = true;
-        }
-        if motor_requested {
-            plot_config.motor_spectrums = true;
-        }
-        if spectrums_requested {
-            plot_config.gyro_spectrums = true;
-            plot_config.d_term_spectrums = true;
-        }
-        if tracking_requested {
-            plot_config.setpoint_vs_gyro = true;
-        }
-        if gyro_filt_requested {
-            plot_config.gyro_vs_unfilt = true;
+            cfg.step_response = true;
         }
         if bode_requested {
-            plot_config.bode = true;
+            cfg.bode = true;
         }
-        if pid_requested {
-            plot_config.pid_activity = true;
-            plot_config.pidsum_error_setpoint = true;
-        }
-        if setpoint_requested {
-            plot_config.setpoint_vs_gyro = true;
-            plot_config.setpoint_derivative = true;
-        }
-        if psd_requested {
-            plot_config.psd = true;
-            plot_config.d_term_psd = true;
-        }
-        if heatmaps_requested {
-            plot_config.psd_db_heatmap = true;
-            plot_config.throttle_freq_heatmap = true;
-            plot_config.d_term_heatmap = true;
-        }
-    }
+        cfg
+    } else {
+        PlotConfig::default()
+    };
 
     // Show debug information when the runtime --debug flag is present
     if debug_mode {
         println!(
-            "DEBUG: has_only_flags={}, step_requested={}, motor_requested={}, setpoint_requested={}, plot_config={:?}",
-            has_only_flags, step_requested, motor_requested, setpoint_requested, plot_config
+            "DEBUG: extended={}, step={}, bode={}, plot_config={:?}",
+            extended_requested, step_requested, bode_requested, plot_config
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -398,9 +398,8 @@ fn print_usage_and_exit(program_name: &str) {
     eprintln!("  --spectrums:     Generate only gyro and D-term spectrum plots.");
     eprintln!("  --tracking:      Generate only setpoint vs gyro tracking plot.");
     eprintln!("  --gyro-filt:     Generate only gyro vs unfiltered (latency) plot.");
-    eprintln!(
-        "  --pid:           Generate only PID-related plots (Tracking, FF, Activity & Error)."
-    );
+    eprintln!("  --setpoint:      Generate only setpoint-related plots (Tracking & FF).");
+    eprintln!("  --pid:           Generate only PID-related plots (Activity & Error).");
     eprintln!("  --psd:           Generate only PSD plots (Gyro & D-term).");
     eprintln!("  --heatmaps:      Generate only spectral heatmaps.");
     eprintln!(
@@ -1554,6 +1553,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut spectrums_requested = false;
     let mut tracking_requested = false;
     let mut gyro_filt_requested = false;
+    let mut setpoint_requested = false;
     let mut bode_requested = false;
     let mut pid_requested = false;
     let mut psd_requested = false;
@@ -1629,6 +1629,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         } else if arg == "--gyro-filt" {
             has_only_flags = true;
             gyro_filt_requested = true;
+        } else if arg == "--setpoint" {
+            has_only_flags = true;
+            setpoint_requested = true;
         } else if arg == "--bode" {
             has_only_flags = true;
             bode_requested = true;
@@ -1694,6 +1697,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         if pid_requested {
             plot_config.pid_activity = true;
             plot_config.pidsum_error_setpoint = true;
+        }
+        if setpoint_requested {
             plot_config.setpoint_vs_gyro = true;
             plot_config.setpoint_derivative = true;
         }
@@ -1711,8 +1716,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Show debug information when the runtime --debug flag is present
     if debug_mode {
         println!(
-            "DEBUG: has_only_flags={}, step_requested={}, motor_requested={}, pid_requested={}, plot_config={:?}",
-            has_only_flags, step_requested, motor_requested, pid_requested, plot_config
+            "DEBUG: has_only_flags={}, step_requested={}, motor_requested={}, setpoint_requested={}, plot_config={:?}",
+            has_only_flags, step_requested, motor_requested, setpoint_requested, plot_config
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -398,8 +398,9 @@ fn print_usage_and_exit(program_name: &str) {
     eprintln!("  --spectrums:     Generate only gyro and D-term spectrum plots.");
     eprintln!("  --tracking:      Generate only setpoint vs gyro tracking plot.");
     eprintln!("  --gyro-filt:     Generate only gyro vs unfiltered (latency) plot.");
-    eprintln!("  --setpoint:      Generate only setpoint-related plots (Tracking & FF).");
-    eprintln!("  --pid:           Generate only PID-related plots (Activity & Error).");
+    eprintln!(
+        "  --pid:           Generate only PID-related plots (Tracking, FF, Activity & Error)."
+    );
     eprintln!("  --psd:           Generate only PSD plots (Gyro & D-term).");
     eprintln!("  --heatmaps:      Generate only spectral heatmaps.");
     eprintln!(
@@ -1553,7 +1554,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut spectrums_requested = false;
     let mut tracking_requested = false;
     let mut gyro_filt_requested = false;
-    let mut setpoint_requested = false;
     let mut bode_requested = false;
     let mut pid_requested = false;
     let mut psd_requested = false;
@@ -1629,9 +1629,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         } else if arg == "--gyro-filt" {
             has_only_flags = true;
             gyro_filt_requested = true;
-        } else if arg == "--setpoint" {
-            has_only_flags = true;
-            setpoint_requested = true;
         } else if arg == "--bode" {
             has_only_flags = true;
             bode_requested = true;
@@ -1697,8 +1694,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         if pid_requested {
             plot_config.pid_activity = true;
             plot_config.pidsum_error_setpoint = true;
-        }
-        if setpoint_requested {
             plot_config.setpoint_vs_gyro = true;
             plot_config.setpoint_derivative = true;
         }
@@ -1716,8 +1711,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Show debug information when the runtime --debug flag is present
     if debug_mode {
         println!(
-            "DEBUG: has_only_flags={}, step_requested={}, motor_requested={}, setpoint_requested={}, plot_config={:?}",
-            has_only_flags, step_requested, motor_requested, setpoint_requested, plot_config
+            "DEBUG: has_only_flags={}, step_requested={}, motor_requested={}, pid_requested={}, plot_config={:?}",
+            has_only_flags, step_requested, motor_requested, pid_requested, plot_config
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,23 +50,24 @@ struct PlotConfig {
 }
 
 impl Default for PlotConfig {
+    /// Core plots only (enabled by default)
     fn default() -> Self {
         Self {
             step_response: true,
-            pidsum_error_setpoint: true,
+            pidsum_error_setpoint: false,
             setpoint_vs_gyro: true,
-            setpoint_derivative: true,
+            setpoint_derivative: false,
             gyro_vs_unfilt: true,
             gyro_spectrums: true,
-            d_term_psd: true,
+            d_term_psd: false,
             d_term_spectrums: true,
-            psd: true,
-            psd_db_heatmap: true,
-            throttle_freq_heatmap: true,
-            d_term_heatmap: true,
+            psd: false,
+            psd_db_heatmap: false,
+            throttle_freq_heatmap: false,
+            d_term_heatmap: false,
             motor_spectrums: true,
             bode: false,
-            pid_activity: true,
+            pid_activity: false,
         }
     }
 }
@@ -89,6 +90,26 @@ impl PlotConfig {
             motor_spectrums: false,
             bode: false,
             pid_activity: false,
+        }
+    }
+
+    fn all() -> Self {
+        Self {
+            step_response: true,
+            pidsum_error_setpoint: true,
+            setpoint_vs_gyro: true,
+            setpoint_derivative: true,
+            gyro_vs_unfilt: true,
+            gyro_spectrums: true,
+            d_term_psd: true,
+            d_term_spectrums: true,
+            psd: true,
+            psd_db_heatmap: true,
+            throttle_freq_heatmap: true,
+            d_term_heatmap: true,
+            motor_spectrums: true,
+            bode: false, // Bode requires specialized logs
+            pid_activity: true,
         }
     }
 }
@@ -364,13 +385,27 @@ fn print_usage_and_exit(program_name: &str) {
     eprintln!();
     eprintln!("=== PLOT TYPE SELECTION ===");
     eprintln!();
-    eprintln!("  Note: Plot flags are combinable. Without flags, all plots generated.");
+    eprintln!("  Note: Plot flags are combinable and switch the application to \"Only\" mode.");
     eprintln!();
-    eprintln!("  --step: Generate only step response plots.");
-    eprintln!("  --motor: Generate only motor spectrum plots.");
-    eprintln!("  --setpoint: Generate only setpoint-related plots.");
-    eprintln!("  --pid: Generate only P, I, D activity plot.");
-    eprintln!("  --bode: Bode plot analysis (requires chirp/sweep system-id test flight, not normal logs).");
+    eprintln!(
+        "  --core:          Generate core plots (Step, Spectrums, Tracking, Latency) [DEFAULT]."
+    );
+    eprintln!("  --extended:      Generate all plots (except Bode).");
+    eprintln!();
+    eprintln!("  --step:          Generate only step response plots.");
+    eprintln!("  --motor:         Generate only motor spectrum plots.");
+    eprintln!("  --spectrums:     Generate only gyro and D-term spectrum plots.");
+    eprintln!("  --tracking:      Generate only setpoint vs gyro tracking plot.");
+    eprintln!("  --gyro-filt:     Generate only gyro vs unfiltered (latency) plot.");
+    eprintln!("  --setpoint:      Generate only setpoint-related plots (Tracking & FF).");
+    eprintln!("  --pid:           Generate only PID-related plots (Activity & Error).");
+    eprintln!("  --psd:           Generate only PSD plots (Gyro & D-term).");
+    eprintln!("  --heatmaps:      Generate only spectral heatmaps.");
+    eprintln!("  --setpoint-diff: Generate only setpoint derivative (FF) plot.");
+    eprintln!(
+        "  --bode:          Bode plot analysis (requires chirp/sweep system-id test flight)."
+    );
+
     eprintln!();
     eprintln!("=== ANALYSIS OPTIONS ===");
     eprintln!();
@@ -1516,9 +1551,17 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut has_only_flags = false;
     let mut step_requested = false;
     let mut motor_requested = false;
+    let mut spectrums_requested = false;
+    let mut tracking_requested = false;
+    let mut gyro_filt_requested = false;
     let mut setpoint_requested = false;
     let mut bode_requested = false;
     let mut pid_requested = false;
+    let mut psd_requested = false;
+    let mut heatmaps_requested = false;
+    let mut diff_requested = false;
+    let mut core_requested = false;
+    let mut extended_requested = false;
     let mut recursive = false;
     let mut estimate_optimal_p = false;
 
@@ -1579,6 +1622,15 @@ fn main() -> Result<(), Box<dyn Error>> {
         } else if arg == "--motor" {
             has_only_flags = true;
             motor_requested = true;
+        } else if arg == "--spectrums" {
+            has_only_flags = true;
+            spectrums_requested = true;
+        } else if arg == "--tracking" {
+            has_only_flags = true;
+            tracking_requested = true;
+        } else if arg == "--gyro-filt" {
+            has_only_flags = true;
+            gyro_filt_requested = true;
         } else if arg == "--setpoint" {
             has_only_flags = true;
             setpoint_requested = true;
@@ -1588,6 +1640,21 @@ fn main() -> Result<(), Box<dyn Error>> {
         } else if arg == "--pid" {
             has_only_flags = true;
             pid_requested = true;
+        } else if arg == "--psd" {
+            has_only_flags = true;
+            psd_requested = true;
+        } else if arg == "--heatmaps" {
+            has_only_flags = true;
+            heatmaps_requested = true;
+        } else if arg == "--setpoint-diff" {
+            has_only_flags = true;
+            diff_requested = true;
+        } else if arg == "--core" {
+            has_only_flags = true;
+            core_requested = true;
+        } else if arg == "--extended" {
+            has_only_flags = true;
+            extended_requested = true;
         } else if arg == "--estimate-optimal-p" {
             estimate_optimal_p = true;
         } else if arg.starts_with("--") {
@@ -1602,13 +1669,49 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Apply "only" flags if any were specified (non-mutually exclusive: OR together)
     if has_only_flags {
         plot_config = PlotConfig::none();
-        plot_config.step_response = step_requested;
-        plot_config.motor_spectrums = motor_requested;
-        plot_config.bode = bode_requested;
-        plot_config.pid_activity = pid_requested;
-        if setpoint_requested {
-            plot_config.pidsum_error_setpoint = true;
+        if core_requested {
+            plot_config = PlotConfig::default();
+        }
+        if extended_requested {
+            plot_config = PlotConfig::all();
+        }
+        if step_requested {
+            plot_config.step_response = true;
+        }
+        if motor_requested {
+            plot_config.motor_spectrums = true;
+        }
+        if spectrums_requested {
+            plot_config.gyro_spectrums = true;
+            plot_config.d_term_spectrums = true;
+        }
+        if tracking_requested {
             plot_config.setpoint_vs_gyro = true;
+        }
+        if gyro_filt_requested {
+            plot_config.gyro_vs_unfilt = true;
+        }
+        if bode_requested {
+            plot_config.bode = true;
+        }
+        if pid_requested {
+            plot_config.pid_activity = true;
+            plot_config.pidsum_error_setpoint = true;
+        }
+        if setpoint_requested {
+            plot_config.setpoint_vs_gyro = true;
+            plot_config.setpoint_derivative = true;
+        }
+        if psd_requested {
+            plot_config.psd = true;
+            plot_config.d_term_psd = true;
+        }
+        if heatmaps_requested {
+            plot_config.psd_db_heatmap = true;
+            plot_config.throttle_freq_heatmap = true;
+            plot_config.d_term_heatmap = true;
+        }
+        if diff_requested {
             plot_config.setpoint_derivative = true;
         }
     }
@@ -1743,5 +1846,3 @@ Some files could not be processed successfully."
         Ok(())
     }
 }
-
-// src/main.rs

--- a/src/main.rs
+++ b/src/main.rs
@@ -401,11 +401,9 @@ fn print_usage_and_exit(program_name: &str) {
     eprintln!("  --pid:           Generate only PID-related plots (Activity & Error).");
     eprintln!("  --psd:           Generate only PSD plots (Gyro & D-term).");
     eprintln!("  --heatmaps:      Generate only spectral heatmaps.");
-    eprintln!("  --setpoint-diff: Generate only setpoint derivative (FF) plot.");
     eprintln!(
         "  --bode:          Bode plot analysis (requires chirp/sweep system-id test flight)."
     );
-
     eprintln!();
     eprintln!("=== ANALYSIS OPTIONS ===");
     eprintln!();
@@ -1559,7 +1557,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut pid_requested = false;
     let mut psd_requested = false;
     let mut heatmaps_requested = false;
-    let mut diff_requested = false;
     let mut core_requested = false;
     let mut extended_requested = false;
     let mut recursive = false;
@@ -1646,9 +1643,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         } else if arg == "--heatmaps" {
             has_only_flags = true;
             heatmaps_requested = true;
-        } else if arg == "--setpoint-diff" {
-            has_only_flags = true;
-            diff_requested = true;
         } else if arg == "--core" {
             has_only_flags = true;
             core_requested = true;
@@ -1710,9 +1704,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             plot_config.psd_db_heatmap = true;
             plot_config.throttle_freq_heatmap = true;
             plot_config.d_term_heatmap = true;
-        }
-        if diff_requested {
-            plot_config.setpoint_derivative = true;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,7 +388,7 @@ fn print_usage_and_exit(program_name: &str) {
     eprintln!("  Note: Plot flags are combinable and switch the application to \"Only\" mode.");
     eprintln!();
     eprintln!(
-        "  --core:          Generate core plots (Step, Spectrums, Tracking, Latency) [DEFAULT]."
+        "  --core:          Generate core plots (Step, Spectrums, Tracking, Latency, Motor) [DEFAULT]."
     );
     eprintln!("  --extended:      Generate all plots (except Bode).");
     eprintln!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ fn get_version_string() -> String {
 }
 
 // Plot configuration struct
+// NOTE: When adding a field here, update none(), Default::default(), and all() accordingly.
 #[derive(Debug, Clone, Copy)]
 struct PlotConfig {
     pub step_response: bool,
@@ -1660,15 +1661,20 @@ fn main() -> Result<(), Box<dyn Error>> {
         i += 1;
     }
 
+    if core_requested && extended_requested {
+        eprintln!("Error: --core and --extended are mutually exclusive.");
+        print_usage_and_exit(program_name);
+    }
+
     // Apply "only" flags if any were specified (non-mutually exclusive: OR together)
     if has_only_flags {
-        plot_config = PlotConfig::none();
-        if core_requested {
-            plot_config = PlotConfig::default();
-        }
-        if extended_requested {
-            plot_config = PlotConfig::all();
-        }
+        plot_config = if core_requested {
+            PlotConfig::default()
+        } else if extended_requested {
+            PlotConfig::all()
+        } else {
+            PlotConfig::none()
+        };
         if step_requested {
             plot_config.step_response = true;
         }


### PR DESCRIPTION
AI Generated pull-request

Rethinks default output to reduce file clutter for typical users while keeping
deep-analysis plots accessible via `--extended`.

### Changes

**Default behavior (no flags):** Core plots only —
Step Response, Gyro Spectrums, D-term Spectrums, Setpoint vs Gyro,
Gyro vs Unfiltered, Motor Spectrums.

**New flags:**
- `--core` [default] — Step Response, Gyro Spectrums, D-term Spectrums, Setpoint vs Gyro, Gyro vs Unfiltered, Motor Spectrums. (`--core` and `--extended` are mutually exclusive)
- `--extended` — all plots except Bode (adds PIDsum/Error, PID Activity, Setpoint Derivative, Gyro PSD, D-term PSD, and heatmaps to the core set)

**Unchanged flags:** `--step`, `--bode`, `--butterworth`, `--dps`, `--estimate-optimal-p` (now marked `[EXPERIMENTAL]` in help), `--debug`, `-R`/`--recursive`, `-O`/`--output-dir`.

**`--debug` behavior tightened:** Flight data key mapping table (per-channel header detection) is now gated behind `--debug`. The fallback warning `⚠️ Using debug[0-2] as fallback for gyroUnfilt[0-2]` and `Debug mode value: N` remain always visible.

### Removed (existed in master)
- `--motor` — motor spectrums are now always part of the core default
- `--setpoint` — setpoint plots are part of core (`SetpointVsGyro`, `GyroVsUnfilt`) or extended (`PIDsum/Error`, `SetpointDerivative`)
- `--pid` — PID plots (`PID_Activity`, `PIDsum_PIDerror`) are part of extended

### Migration
Scripts using `--step` or `--bode` continue to work unchanged.
Scripts relying on all plots being generated by default should add `--extended`.

### Documentation
README.md and OVERVIEW.md updated with accurate core/extended plot lists and CLI surface.